### PR TITLE
fix(search): set autocapitalize off in search input ( #13 )

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,22 @@
 
 <div class="input-container">
     <div class="input-with-checkbox">
-        <label for="word-lookup-input">
-            <input type="text" id="word-lookup-input" placeholder="Type a word..." autocomplete="off">
-        </label>
+        <label for="word-lookup-input">Search</label>
+        <input
+                id="word-lookup-input"
+                type="search"
+                autocomplete="off"
+                autocapitalize="off"
+                autocorrect="off"
+                spellcheck="false"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-controls="word-suggestions"
+                aria-expanded="false"
+                placeholder="Type any form..."
+        />
         <label>
-        <input type="checkbox" id="suffix-search"> Suffix Search
+            <input type="checkbox" id="suffix-search"> Search word endings
         </label>
     </div>
     <div id="word-suggestions"></div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // Minimum number of characters before triggering autocomplete
-export const QUERY_CHAR_MIN = 2;
+export const QUERY_CHAR_MIN = 1;
 
 export const PartOfSpeech = Object.freeze({
     NOUN:      "nom",


### PR DESCRIPTION
First letter getting capitalized on mobile devices. Especially problematic, because currently the search-function is case-sensitive and won't return case-insensitive matches.