### PR TITLE
chore(ci): add GitHub Actions workflow for frontend deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy LexiconMeum Frontend
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [ master ]
+
+concurrency:
+  group: lexiconmeum-frontend-prod
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      REMOTE_USER: admin
+      REMOTE_SERVER: ${{ secrets.VPS_IP_PROD }}
+      WEB_ROOT: /var/www/lexiconmeum-frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x (with npm cache)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build (Vite)
+        run: npm run build
+
+      - name: Tar build artifacts
+        run: tar -czf dist.tar.gz -C dist .
+
+      - name: Set up SSH
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Add server to known hosts
+        run: ssh-keyscan -H ${{ env.REMOTE_SERVER }} >> ~/.ssh/known_hosts
+
+      - name: Upload bundle
+        run: rsync -avz -e "ssh" dist.tar.gz ${{ env.REMOTE_USER }}@${{ env.REMOTE_SERVER }}:~/frontend-dist.tar.gz
+
+      - name: Deploy to VPS (atomic with rollback)
+        run: |
+          set -euo pipefail
+          RELEASE="release-$(date -u +%Y%m%d%H%M%S)-${GITHUB_SHA::7}"
+
+          ssh ${{ env.REMOTE_USER }}@${{ env.REMOTE_SERVER }} << EOF
+            set -euo pipefail
+            WEB_ROOT="${WEB_ROOT}"
+            RELEASE="${RELEASE}"
+
+            # Prepare dirs
+            sudo mkdir -p "$WEB_ROOT/releases"
+
+            # Unpack to new release dir
+            sudo mkdir -p "$WEB_ROOT/releases/$RELEASE"
+            sudo tar -xzf ~/frontend-dist.tar.gz -C "$WEB_ROOT/releases/$RELEASE"
+
+            # Atomically point current -> new release
+            sudo ln -sfn "$WEB_ROOT/releases/$RELEASE" "$WEB_ROOT/current"
+
+            # Optional: keep last 5 releases, delete older
+            sudo sh -c "ls -1dt $WEB_ROOT/releases/* | tail -n +6 | xargs -r rm -rf"
+
+            # Cleanup uploaded tar
+            rm -f ~/frontend-dist.tar.gz
+          EOF


### PR DESCRIPTION
- Build frontend with Vite on push to master
- Package dist/ output and upload to VPS
- Deploy to versioned releases directory with atomic symlink swap
- Retain last 5 releases for quick rollback