### PR TITLE
Refactor rendering into dedicated modules + add robust tests for detail and search flows

### DIFF
--- a/src/detail/handleLoadWordDetail.js
+++ b/src/detail/handleLoadWordDetail.js
@@ -1,0 +1,15 @@
+import { fetchWordDetailData } from "../api/apiClient.js";
+import { renderWordDetail } from "./renderWordDetail.js";
+import {toErrorMessage} from "@src/utils/errors.js";
+
+export async function handleLoadWordDetail(lemma, lexemeId) {
+  try {
+    const data = await fetchWordDetailData(lemma, lexemeId);
+    renderWordDetail(data);
+  } catch (err) {
+    const raw = toErrorMessage(err,  "There was a problem loading details.")
+
+    const actionWord = raw.includes("fetch") ? "loading" : "displaying";
+    throw new Error(`There was a problem ${actionWord} details for ${lemma}.`);
+  }
+}

--- a/src/detail/renderAdjectiveAgreementTable.js
+++ b/src/detail/renderAdjectiveAgreementTable.js
@@ -1,22 +1,26 @@
 const GENDER_ABBR = { MASCULINE: "m", FEMININE: "f", NEUTER: "n" };
-// define your canonical sort order:
+
+// define  canonical sort order:
 const GENDER_ORDER = ["MASCULINE", "FEMININE", "NEUTER"];
 
 export function renderAdjectiveAgreementTable(agreements) {
-    if (!agreements?.length) return;
+    const container = document.getElementById("inflections-container");
+    container.replaceChildren();
+
+    if (!Array.isArray(agreements) || agreements.length === 0) {
+        return;
+    }
 
     // --- sort agreements by the lowest-index gender they contain ---
     agreements = agreements.slice().sort((a, b) => {
-        const minIndex = arr =>
-            Math.min(...arr.map(g => GENDER_ORDER.indexOf(g)));
+        const minIndex = (arr) =>
+            Math.min(...arr.map((g) => GENDER_ORDER.indexOf(g)));
         return minIndex(a.genders) - minIndex(b.genders);
     });
 
     const numbers = Object.keys(agreements[0].inflections);
-    const cases   = Object.keys(agreements[0].inflections[numbers[0]]);
+    const cases = Object.keys(agreements[0].inflections[numbers[0]]);
 
-    const container = document.getElementById("inflections-container");
-    container.innerHTML = "";
 
     const table = document.createElement("table");
     table.classList.add("latin-table", "agreement-table");
@@ -28,70 +32,70 @@ export function renderAdjectiveAgreementTable(agreements) {
     const tbody = table.appendChild(document.createElement("tbody"));
     tbody.append(addCaseRows(agreements, cases, numbers[0]));
     tbody.append(
-        createSectionHeaderRow(numbers[1], agreements.length + 1, "section-header")
+        createSectionHeaderRow(numbers[1], agreements.length + 1, "section-header"),
     );
     tbody.append(addCaseRows(agreements, cases, numbers[1]));
 }
 
 function getHeaderRow(numberLabel, agreements) {
-    const tr = document.createElement("tr");
-    const th = document.createElement("th");
-    th.textContent = numberLabel;
-    tr.appendChild(th);
+  const tr = document.createElement("tr");
+  const th = document.createElement("th");
+  th.textContent = numberLabel;
+  tr.appendChild(th);
 
-    agreements.forEach(({ genders }) => {
-        const cell = document.createElement("th");
-        cell.scope = "col";
-        cell.textContent = formatGenderLabel(genders);
-        tr.appendChild(cell);
-    });
+  agreements.forEach(({ genders }) => {
+    const cell = document.createElement("th");
+    cell.scope = "col";
+    cell.textContent = formatGenderLabel(genders);
+    tr.appendChild(cell);
+  });
 
-    return tr;
+  return tr;
 }
 
 function formatGenderLabel(genders) {
-    const sorted = [...genders].sort(
-        (a, b) => GENDER_ORDER.indexOf(a) - GENDER_ORDER.indexOf(b)
-    );
-    const abbrs = sorted.map(g => GENDER_ABBR[g] || g.charAt(0).toLowerCase());
-    return abbrs.join(" & ");
+  const sorted = [...genders].sort(
+    (a, b) => GENDER_ORDER.indexOf(a) - GENDER_ORDER.indexOf(b),
+  );
+  const abbrs = sorted.map((g) => GENDER_ABBR[g] || g.charAt(0).toLowerCase());
+  return abbrs.join(" & ");
 }
 
 function addCaseRows(agreements, cases, numberLabel) {
-    const frag = document.createDocumentFragment();
+  const frag = document.createDocumentFragment();
 
-    cases.forEach(gramCase => {
-        const row = document.createElement("tr");
-        const caseTh = document.createElement("th");
-        caseTh.scope = "row";
-        caseTh.textContent = abbrevCase(gramCase);
-        row.appendChild(caseTh);
+  cases.forEach((gramCase) => {
+    const row = document.createElement("tr");
+    const caseTh = document.createElement("th");
+    caseTh.scope = "row";
+    caseTh.textContent = abbrevCase(gramCase);
+    row.appendChild(caseTh);
 
-        agreements.forEach(({ inflections }) => {
-            const td = document.createElement("td");
+    agreements.forEach(({ inflections }) => {
+      const td = document.createElement("td");
 
-            td.textContent = inflections[numberLabel]?.[gramCase] ?? "";
-            row.appendChild(td);
-        });
-
-        frag.appendChild(row);
+      td.textContent = inflections[numberLabel]?.[gramCase] ?? "";
+      row.appendChild(td);
     });
 
-    return frag;
+    frag.appendChild(row);
+  });
+
+  return frag;
 }
 
 function abbrevCase(name) {
-    const p = name.slice(0, 3);
-    return p.charAt(0) + p.slice(1).toLowerCase() + ".";
+  const p = name.slice(0, 3);
+  return p.charAt(0) + p.slice(1).toLowerCase() + ".";
 }
 
 function createSectionHeaderRow(label, colspan, cls) {
-    const row = document.createElement("tr");
-    const cell = document.createElement("th");
-    cell.scope = "col";
-    cell.colSpan = colspan;
-    cell.textContent = label;
-    cell.classList.add(cls);
-    row.appendChild(cell);
-    return row;
+  const row = document.createElement("tr");
+  const cell = document.createElement("th");
+  cell.scope = "col";
+  cell.colSpan = colspan;
+  cell.textContent = label;
+  cell.classList.add(cls);
+  row.appendChild(cell);
+  return row;
 }

--- a/src/detail/renderAdverbSpecificElements.js
+++ b/src/detail/renderAdverbSpecificElements.js
@@ -1,0 +1,19 @@
+import {formatPOS} from "@src/utils/formatPartOfSpeech.js";
+
+export function renderAdverbSpecificContent(partOfSpeech){
+    if (partOfSpeech !== "ADVERB") { 
+        return; 
+    }
+
+    const container = document.getElementById("lemma-container");
+    if (!container) return;
+
+    //  remove only prior adverb marker(s) not the whole lemma-header
+    container.querySelectorAll(".grammatical-position").forEach(n => n.remove());
+
+    const positionSpan = document.createElement("span");
+    positionSpan.classList.add("grammatical-position");
+    positionSpan.textContent = `  (${formatPOS(partOfSpeech)})`;
+
+    container.appendChild(positionSpan);
+}

--- a/src/detail/renderDeclensionTable.js
+++ b/src/detail/renderDeclensionTable.js
@@ -1,15 +1,25 @@
-export function renderDeclensionTable(data) {
-    const tableData = data.inflectionTable.declensions;
+export function renderDeclensionTable(declensions) {
+
+    // Replace existing content
+    const container = document.getElementById("inflections-container");
+    container.replaceChildren();
+
+    //only render this table if this is declension data
+    if (!declensions?.SINGULAR || !declensions?.PLURAL) {
+      return;
+    }
+
+    const tableData = declensions;
     const cases = Object.keys(tableData.SINGULAR); // Assume both singular and plural have same cases
 
     const table = document.createElement("table");
     table.classList.add("latin-table");
     table.classList.add("declension-table");
 
-    // Create table header
+    // Create the table header
     const thead = document.createElement("thead");
     const headerRow = document.createElement("tr");
-    ["Case", "Singular", "Plural"].forEach(heading => {
+    ["Case", "Singular", "Plural"].forEach((heading) => {
         const th = document.createElement("th");
         th.textContent = heading;
         headerRow.appendChild(th);
@@ -19,32 +29,31 @@ export function renderDeclensionTable(data) {
 
     // Create table body
     const tbody = document.createElement("tbody");
-    cases.forEach(c => {
-        const row = document.createElement("tr");
 
-        const caseCell = document.createElement("td");
-        caseCell.textContent = capitalize(c.toLowerCase());
-        row.appendChild(caseCell);
+    cases.forEach((c) => {
+    const row = document.createElement("tr");
 
-        const singularCell = document.createElement("td");
-        singularCell.textContent = tableData.SINGULAR[c] || "";
-        row.appendChild(singularCell);
+    const caseCell = document.createElement("td");
+    caseCell.textContent = capitalize(c.toLowerCase());
+    row.appendChild(caseCell);
 
-        const pluralCell = document.createElement("td");
-        pluralCell.textContent = tableData.PLURAL[c] || "";
-        row.appendChild(pluralCell);
+    const singularCell = document.createElement("td");
+    singularCell.textContent = tableData.SINGULAR[c] || "";
+    row.appendChild(singularCell);
 
-        tbody.appendChild(row);
-    });
-    table.appendChild(tbody);
+    const pluralCell = document.createElement("td");
+    pluralCell.textContent = tableData.PLURAL[c] || "";
+    row.appendChild(pluralCell);
 
-    // Replace existing content
-    const container = document.getElementById("inflections-container");
-    container.innerHTML = "";
-    container.appendChild(table);
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+
+
+  container.appendChild(table);
 }
 
 // Helper to capitalize strings
 function capitalize(str) {
-    return str.charAt(0).toUpperCase() + str.slice(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/src/detail/renderDefinitions.js
+++ b/src/detail/renderDefinitions.js
@@ -1,52 +1,58 @@
 export function renderDefinitions(definitions) {
-    const container = document.getElementById("definitions-container");
-    container.innerHTML = "";
+  const container = document.getElementById("definitions-container");
+  container.innerHTML = "";
 
-    const definitionsLabelSpan = document.createElement("span");
-    definitionsLabelSpan.classList.add("definitions-label");
-    definitionsLabelSpan.textContent = "Definitions:";
-    container.appendChild(definitionsLabelSpan);
+  const definitionsLabelSpan = document.createElement("span");
+  definitionsLabelSpan.classList.add("definitions-label");
+  definitionsLabelSpan.textContent = "Definitions:";
+  container.appendChild(definitionsLabelSpan);
 
-    if (!definitions || definitions.length === 0) return;
+  if (!definitions || definitions.length === 0) return;
 
-    const visibleCount = 2;
+  const visibleCount = 2;
+
+    const a = 1;
+    if (a == "1") {
+        // ...
+    }
+
 
     const list = document.createElement("ul");
-    list.classList.add("definitions-list");
+  list.classList.add("definitions-list");
 
-    // First N definitions
-    definitions.slice(0, visibleCount).forEach(def => {
-        const li = document.createElement("li");
-        li.textContent = def;
-        list.appendChild(li);
+  // First N definitions
+  definitions.slice(0, visibleCount).forEach((def) => {
+    const li = document.createElement("li");
+    li.textContent = def;
+    list.appendChild(li);
+  });
+
+  container.appendChild(list);
+
+  // Remainder definitions
+  if (definitions.length > visibleCount) {
+    const hiddenList = document.createElement("ul");
+    hiddenList.classList.add("definitions-list", "definitions-hidden");
+    hiddenList.style.display = "none";
+
+    definitions.slice(visibleCount).forEach((def) => {
+      const li = document.createElement("li");
+      li.textContent = def;
+      hiddenList.appendChild(li);
     });
 
-    container.appendChild(list);
+    container.appendChild(hiddenList);
 
-    // Remainder definitions
-    if (definitions.length > visibleCount) {
-        const hiddenList = document.createElement("ul");
-        hiddenList.classList.add("definitions-list", "definitions-hidden");
-        hiddenList.style.display = "none";
+    // Toggle button
+    const toggle = document.createElement("button");
+    toggle.classList.add("definitions-toggle");
+    toggle.textContent = "Show more";
+    toggle.addEventListener("click", () => {
+      const isHidden = hiddenList.style.display === "none";
+      hiddenList.style.display = isHidden ? "block" : "none";
+      toggle.textContent = isHidden ? "Show less" : "Show more";
+    });
 
-        definitions.slice(visibleCount).forEach(def => {
-            const li = document.createElement("li");
-            li.textContent = def;
-            hiddenList.appendChild(li);
-        });
-
-        container.appendChild(hiddenList);
-
-        // Toggle button
-        const toggle = document.createElement("button");
-        toggle.classList.add("definitions-toggle");
-        toggle.textContent = "Show more";
-        toggle.addEventListener("click", () => {
-            const isHidden = hiddenList.style.display === "none";
-            hiddenList.style.display = isHidden ? "block" : "none";
-            toggle.textContent = isHidden ? "Show less" : "Show more";
-        });
-
-        container.appendChild(toggle);
-    }
+    container.appendChild(toggle);
+  }
 }

--- a/src/detail/renderInflectionType.js
+++ b/src/detail/renderInflectionType.js
@@ -1,18 +1,27 @@
-export function renderInflectionType(inflectionClass, grammaticalPosition) {
-    let container = document.getElementById("inflection-type-container");
-    container.innerHTML = "";
+export function renderInflectionType(inflectionClass, partOfSpeech) {
+  let container = document.getElementById("inflection-type-container");
 
+  container.replaceChildren();
+
+  if (inflectionClass) {
+    let span = document.createElement("span");
+    span.classList.add("inflection-type");
+
+    span.textContent = `${inflectionClass}`;
+    container.appendChild(span);
+  }
+
+  const posRaw = typeof partOfSpeech === "string" ? partOfSpeech.trim() : "";
+  const posLower = posRaw.toLowerCase();
+
+  // Set of POS types that have inflection info (such as an inflection table)
+  // above which it makes sense to add the POS info
+  const POS_POSITION_IN_INFLECTION = new Set(["noun", "verb", "adjective"]);
+
+  if (posLower && POS_POSITION_IN_INFLECTION.has(posLower)) {
     const positionSpan = document.createElement("span");
     positionSpan.classList.add("grammatical-position");
-    positionSpan.textContent = `${grammaticalPosition}`;
-
+    positionSpan.textContent = ` (${posLower})`;
     container.appendChild(positionSpan);
-
-    if (inflectionClass) {
-        let span = document.createElement("span");
-        span.classList.add("inflection-type");
-
-        span.textContent = `${inflectionClass}`;
-        container.appendChild(span);
-    }
+  }
 }

--- a/src/detail/renderLemmaHeader.js
+++ b/src/detail/renderLemmaHeader.js
@@ -1,10 +1,10 @@
 export function renderLemmaHeader(lemma) {
-        const container = document.getElementById("lemma-container");
-        container.innerHTML = "";
+  const container = document.getElementById("lemma-container");
+  container.innerHTML = "";
 
-        const lemmaSpan = document.createElement("span");
-        lemmaSpan.classList.add("lemma");
-        lemmaSpan.textContent = `${lemma}`;
+  const lemmaSpan = document.createElement("span");
+  lemmaSpan.classList.add("lemma");
+  lemmaSpan.textContent = `${lemma}`;
 
-        container.appendChild(lemmaSpan);
+  container.appendChild(lemmaSpan);
 }

--- a/src/detail/renderPrincipalParts.js
+++ b/src/detail/renderPrincipalParts.js
@@ -1,17 +1,16 @@
-
 export function renderPrincipalParts(principalParts) {
 
-    console.log(principalParts );
+  const principalPartsContainer = document.getElementById(
+    "principal-parts-container",
+  );
+  principalPartsContainer.innerHTML = ""; // Clear once at the top
 
-    const principalPartsContainer = document.getElementById("principal-parts-container");
-    principalPartsContainer.innerHTML = ""; // Clear once at the top
+  if (principalParts && principalParts.length > 0) {
+    const span = document.createElement("span");
+    span.classList.add("principal-parts");
 
-    if (principalParts && principalParts.length > 0) {
-        const span = document.createElement("span");
-        span.classList.add("principal-parts");
-
-        // Join parts with commas (no trailing comma)
-        span.textContent = principalParts.join(", ");
-        principalPartsContainer.appendChild(span);
-    }
+    // Join parts with commas (no trailing comma)
+    span.textContent = principalParts.join(", ");
+    principalPartsContainer.appendChild(span);
+  }
 }

--- a/src/detail/renderWordDetail.js
+++ b/src/detail/renderWordDetail.js
@@ -1,0 +1,92 @@
+import { renderDeclensionTable } from "./renderDeclensionTable.js";
+import { renderConjugationTable } from "./renderConjugationTable.js";
+import { renderAdjectiveAgreementTable } from "./renderAdjectiveAgreementTable.js";
+import { renderLemmaHeader } from "./renderLemmaHeader.js";
+import { renderPrincipalParts } from "./renderPrincipalParts.js";
+import { renderDefinitions } from "./renderDefinitions.js";
+import { renderInflectionType } from "./renderInflectionType.js";
+import {renderAdverbSpecificContent} from "@detail/renderAdverbSpecificElements.js";
+/**
+ *  Displays word details
+ *
+ *  Renders elements common to all words
+ *  Routes data for elements specific to partOfSpeech (e.g., NOUN, VERB) to the appropriate renderer
+ *  If the pos is unrecognized, no pos specific action is taken.
+ *  Errors encountered during data rendering are logged and displayed in the UI status element.
+ *
+ * @param wordDetailData
+ */
+export function renderWordDetail(wordDetailData) {
+    const {
+        lemma,
+        position: partOfSpeech,
+        grammaticalGender: gender,
+        inflectionClass,
+        principalParts,
+        definitions,
+    } = wordDetailData;
+
+    try {
+        renderLemmaHeader(lemma);
+        renderDefinitions(definitions);
+
+        renderAdverbSpecificContent(partOfSpeech);
+
+        renderPrincipalParts(principalParts);
+        renderInflectionType(inflectionClass, partOfSpeech);
+
+        // Add noun gender only when relevant and principal parts exist
+        if (partOfSpeech === "NOUN" && principalParts && gender) {
+            addNounGender(gender);
+        }
+
+        const { inflectionTable } = wordDetailData ?? {};
+        const {
+            conjugations = [],
+            agreements = [],
+            declensions = null,
+        } = inflectionTable ?? {};
+
+
+        // Show exactly one inflection table depending on POS; clear otherwise
+        const pos = typeof partOfSpeech === "string" ? partOfSpeech.trim().toUpperCase() : "";
+
+        if (pos === "NOUN") {
+            renderDeclensionTable(declensions);
+        } else if (pos === "VERB") {
+            renderConjugationTable(conjugations, "ACTIVE");
+        } else if (pos === "ADJECTIVE") {
+            renderAdjectiveAgreementTable(agreements);
+        } else {
+            // No inflections for this POS; ensure area is cleared
+            const container = document.getElementById("inflections-container");
+            container && container.replaceChildren();
+        }
+
+    } catch (err) {
+        console.error(`Rendering error for ${lemma} details:`, err);
+        throw err;
+    }
+}
+
+
+function addNounGender(gender) {
+    const container = document.getElementById("principal-parts-container");
+    const ppSpan = container?.querySelector(".principal-parts");
+    if (ppSpan) {
+        const abbr = (typeof gender === "string" && gender.trim().length > 0)
+            ? gender.trim().charAt(0).toLowerCase()
+            : "";
+
+        if (abbr) {
+            // Add a leading space so it reads like: "puella, puellae f."
+            ppSpan.appendChild(document.createTextNode(" "));
+
+            const em = document.createElement("em");
+            em.classList.add("gender");
+            em.textContent = `${abbr}.`;
+            ppSpan.appendChild(em);
+        }
+    }
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,11 @@
 import "./styles/index.css";
-import {renderDeclensionTable} from "./detail/renderDeclensionTable.js";
-import {renderConjugationTable} from "./detail/renderConjugationTable.js";
-import {renderAdjectiveAgreementTable} from "./detail/renderAdjectiveAgreementTable.js";
-import {renderLemmaHeader} from "./detail/renderLemmaHeader.js";
-import {renderPrincipalParts} from "./detail/renderPrincipalParts.js";
-import {renderDefinitions} from "./detail/renderDefinitions.js";
-import {renderInflectionType} from "./detail/renderInflectionType.js";
-import {QUERY_CHAR_MIN, StatusMessageType} from "@src/utils/constants.js";
-import {getLexemeDetailUri, PREFIX_URI, SEARCH_URI, SUFFIX_URI} from "@api";
-import {formatPOS} from "@src/utils/formatPartOfSpeech.js";
+import { QUERY_CHAR_MIN } from "./utils/constants.js";
+import { StatusMessageType } from "./utils/constants.js";
+import { fetchWordSuggestions } from "./api/apiClient.js";
+import { handleWordLookup } from "./search/handleWordLookup.js";
+import { validateQuery } from "./search/validate.js";
+import { transformWordSuggestionData } from "./search/transformWordSuggestionData.js";
+import { handleLoadWordDetail } from "./detail/handleLoadWordDetail.js";
 
 const isSuffixSearch = document.getElementById("suffix-search");
 const wordLookupInput = document.getElementById("word-lookup-input");
@@ -26,24 +23,71 @@ document.documentElement.setAttribute("data-theme", "bronze");
  * If the fetch fails, logs the error and updates the status bar.
  */
 wordLookupInput.addEventListener("input", async () => {
-    const query = wordLookupInput.value.trim();
-    wordSuggestionsBox.innerHTML = "";
+  const query = validateQuery(wordLookupInput.value, QUERY_CHAR_MIN);
+  if (!query) return;
 
-    // wait for at least 2 letters before fetching suggestions
-    if (query.length < QUERY_CHAR_MIN) return;
+  wordSuggestionsBox.innerHTML = "";
 
-    try {
-        let words = await fetchWordSuggestions(query);
-        console.log(words);
-        if (Array.isArray(words) && words.length > 0) {
-            buildWordSuggestionBox(words);
-        }
-    } catch (err) {
-        let message = "Error fetching suggestions: ";
-        console.error(message, err);
-        setStatus(message + query);
-    }
+  const result = await handleWordLookup(query, fetchWordSuggestions, isSuffixSearch.checked);
+
+  if (result.status === "success") {
+    buildWordSuggestionBox(result.data);
+  } else {
+    setStatus(result.message);
+  }
 });
+
+/**
+ * Builds and displays a word suggestion box based on a list of words.
+ *
+ * @param {string[]} words - The list of words to generate suggestions from.
+ * @return {void} This function does not return a value.
+ */
+function buildWordSuggestionBox(rawSuggestions) {
+  const suggestionItems = transformWordSuggestionData(rawSuggestions);
+  renderWordSuggestionBox(
+    suggestionItems,
+    wordSuggestionsBox,
+    handleLoadWordDetail,
+  );
+}
+
+/**
+ * Renders a suggestion box containing word suggestions and adds a selection handler to each.
+ *
+ * @param {Array<{word: string, lexemeId: string, suggestion: string}>} suggestionItems
+ *        An array of suggestion objects, each containing the word, lexeme ID, and the suggestion text.
+ * @param {HTMLElement} wordSuggestionsBox
+ *        The DOM element representing the container where the suggestions will be rendered.
+ * @param {Function} handleLoadWordDetail
+ *        A callback function to execute when a suggestion is selected. Receives the word and lexeme ID as arguments.
+ * @return {void}
+ *        Does not return a value; operates directly on the provided DOM elements.
+ */
+export function renderWordSuggestionBox(
+  suggestionItems,
+  wordSuggestionsBox,
+  handleLoadWordDetail,
+) {
+  wordSuggestionsBox.style.display = "block";
+  suggestionItems.forEach(({ word, lexemeId, suggestion }) => {
+    const item = document.createElement("div");
+    item.textContent = suggestion;
+
+    item.addEventListener("click", async () => {
+    wordSuggestionsBox.innerHTML = "";
+    try {
+        await handleLoadWordDetail(word, lexemeId);
+      } catch (e) {
+        const message = e && typeof e === "object" && "message" in e
+            ? e.message : "There was a problem loading details.";
+        setStatus(message);
+        }
+    });
+
+    wordSuggestionsBox.appendChild(item);
+  });
+    }
 
 /**
  * Hides the word suggestions dropdown when the user clicks outside the input field.
@@ -56,127 +100,12 @@ document.addEventListener("click", (e) => {
 });
 
 /**
- * Fetches auto-complete suggestions for word search input
- * @param query
- * @returns {Promise<any>}
- */
-async function fetchWordSuggestions(query){
-    const subAPI = isSuffixSearch.checked ? SUFFIX_URI : PREFIX_URI
-    const uri = SEARCH_URI + subAPI + encodeURIComponent(query);
-    const res = await fetch( uri);
-    return await res.json();
-}
-
-/**
- * Displays a dropdown of word suggestions below the search input.
- *
- * Given a list of word suggestion objects (each containing `word`, `lexemeId`,
- * and `grammaticalPosition`), this function renders them as clickable items
- * in the suggestion box. Selecting a suggestion clears the dropdown and
- * triggers the display of the corresponding word's detailed table.
- *
- * @param {Array<Object>} words - List of suggestion objects with `word`, `lexemeId`, and `grammaticalPosition` fields.
- */
-function buildWordSuggestionBox(words){
-    wordSuggestionsBox.style.display = "block"
-    words.forEach(wordObj => {
-
-        const { word, lexemeId, grammaticalPosition } = wordObj;
-
-        const item = document.createElement("div");
-
-        console.log("lemma: " + word);
-        item.textContent = `${word} (${ formatPOS(grammaticalPosition )})`;
-        item.addEventListener("click", () => {
-            wordSuggestionsBox.innerHTML = ""; // hide suggestions
-            buildWordDetailTable(word, lexemeId, grammaticalPosition);
-        });
-        wordSuggestionsBox.appendChild(item);
-    });
-}
-
-
-
-
-/**
- * Fetches and displays the full inflection table for a selected word.
- *
- * Routes the request based on the word’s grammatical position (e.g., NOUN, VERB)
- * to the appropriate data-fetching and rendering logic:
- *
- * If the position is unrecognized, no action is taken (or can be handled in the future).
- *
- * Errors encountered during data retrieval are logged and displayed in the UI status element.
- *
- * @param {string} lemma - The base form of the word (used for logging/status).
- * @param {string} lexemeId - Unique identifier used to fetch detailed word data.
- * @param {string} grammaticalPosition - Part of speech (e.g., "NOUN", "VERB", etc.) used to determine routing logic.
- */
-async function buildWordDetailTable(lemma, lexemeId, grammaticalPosition ){
-
-    try {
-        let wordDetailData = await fetchWordDetailData(lexemeId);
-        if (wordDetailData) {
-            const {lemma, inflectionClass, principalParts, definitions} = wordDetailData;
-            renderLemmaHeader(lemma);
-            renderDefinitions(definitions);
-
-            renderInflectionType(inflectionClass, grammaticalPosition);
-
-            renderPrincipalParts(principalParts );
-
-            if (grammaticalPosition === "NOUN") {
-                renderDeclensionTable(wordDetailData);
-
-            } else if (grammaticalPosition === "VERB") {
-                renderConjugationTable(wordDetailData, "ACTIVE");
-
-            } else if (grammaticalPosition === "ADJECTIVE") {
-                const { inflectionTable: { agreements } } = wordDetailData;
-                renderAdjectiveAgreementTable(agreements);
-            }
-            // If not an inflected part of speech,
-            // make sure any inflection info from previous loads is removed
-            else {
-                const container = document.getElementById("inflections-container");
-                container.innerHTML = "";
-            }
-        }
-
-    } catch (err) {
-        let message = `Could not fetch ${lemma} detail`;
-        console.error(message, err);
-        setStatus(message + lemma);
-    }
-}
-
-
-/**
-* Fetches detailed sense and inflection data for a word from the backend API.
-*
-* Constructs the appropriate URI using the provided word's lexeme ID,
-* sends a GET request, parses the JSON response, and returns it.
-*
-* @param {string} word - The word or lexeme ID used to build the declension detail request URI.
-* @returns {Promise<Object>} - The parsed JSON data representing the word's declension details.
-*/
-async function fetchWordDetailData(word) {
-
-    const uri  = getLexemeDetailUri(word)
-    const res = await fetch(uri);
-    let jsn = await res.json();
-    console.log(jsn);
-    return jsn;
-}
-
-
-/**
- * Updates the status bar in the UI with the provided message.
+ * Updates the status display in the UI with the provided message.
  *
  * Intended for communicating errors or status updates to the user,
  * typically during asynchronous operations like fetching word data.
  *
- * @param {string} message - The text message to display in the status bar.
+ * @param {string} message - The text message to display in the status display component.
  */
 function setStatus(message) {
   if (message) {

--- a/src/search/handleWordLookup.js
+++ b/src/search/handleWordLookup.js
@@ -1,0 +1,18 @@
+export async function handleWordLookup(query, fetchSuggestions, isSuffixSearch) {
+
+    const trimmedQuery = query.trim();
+  try {
+    const suggestions = await fetchSuggestions(trimmedQuery, isSuffixSearch);
+
+    if (Array.isArray(suggestions) && suggestions.length > 0) {
+      return { status: "success", data: suggestions };
+    } else {
+      return { status: "error", message: "No suggestions found" };
+    }
+  } catch {
+    return {
+      status: "error",
+      message: `We're having trouble fetching suggestions right now. Please try again later.`,
+    };
+  }
+}

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -1,0 +1,3 @@
+export { handleWordLookup } from "./handleWordLookup.js";
+export { transformWordSuggestionData } from "./transformWordSuggestionData";
+export { validateQuery } from "./validate.js";

--- a/src/search/transformWordSuggestionData.js
+++ b/src/search/transformWordSuggestionData.js
@@ -1,0 +1,23 @@
+import {formatPOS} from "@src/utils/formatPartOfSpeech.js";
+
+export function transformWordSuggestionData(wordSuggestionData) {
+  return wordSuggestionData
+    .map((suggestionDatum) => {
+      const {
+        word,
+        lexemeId,
+        grammaticalPosition: partOfSpeech,
+      } = suggestionDatum;
+      let suggestion;
+
+      if (word && partOfSpeech && lexemeId) {
+        suggestion = `${word} (${formatPOS(partOfSpeech)})`;
+        return { word, lexemeId, suggestion };
+      } else {
+        return null;
+      }
+    })
+    .filter(Boolean); // Remove null values from the array
+}
+
+

--- a/src/search/validate.js
+++ b/src/search/validate.js
@@ -1,0 +1,4 @@
+export function validateQuery(query, minQueryLength) {
+  const trimmedQuery = query.trim();
+  return trimmedQuery.length >= minQueryLength ? trimmedQuery : null;
+}

--- a/test/detail/handleLoadWordDetail.test.js
+++ b/test/detail/handleLoadWordDetail.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock dependencies used by handleLoadWordDetail.js
+vi.mock("@api/apiClient.js", () => ({
+  fetchWordDetailData: vi.fn(),
+}));
+vi.mock("@detail/renderWordDetail.js", () => ({
+  renderWordDetail: vi.fn(),
+}));
+
+// Import the mocks for assertions from the same paths
+import { fetchWordDetailData } from "@api/apiClient.js";
+import { renderWordDetail } from "@detail/renderWordDetail.js";
+
+// Import the SUT directly to avoid barrel side effects
+import { handleLoadWordDetail } from "@detail/handleLoadWordDetail.js";
+
+describe("handleLoadWordDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders on success", async () => {
+    const data = { word: "example" };
+    fetchWordDetailData.mockResolvedValueOnce(data);
+
+    await handleLoadWordDetail("example", 123);
+
+    expect(fetchWordDetailData).toHaveBeenCalledWith("example", 123);
+    expect(renderWordDetail).toHaveBeenCalledWith(data);
+  });
+
+  it("throws loading error on fetch error", async () => {
+    fetchWordDetailData.mockRejectedValueOnce(new Error("fetch failed"));
+
+    await expect(handleLoadWordDetail("example", 123))
+      .rejects.toThrow("There was a problem loading details for example.");
+    expect(renderWordDetail).not.toHaveBeenCalled();
+  });
+
+  it("throws displaying error on non-fetch error", async () => {
+    fetchWordDetailData.mockRejectedValueOnce(new Error("unexpected"));
+
+    await expect(handleLoadWordDetail("test", 456))
+      .rejects.toThrow("There was a problem displaying details for test.");
+    expect(renderWordDetail).not.toHaveBeenCalled();
+  });
+});

--- a/test/detail/renderWordDetail.clearing.test.js
+++ b/test/detail/renderWordDetail.clearing.test.js
@@ -1,0 +1,175 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Lightweight mocks for the 3 inflection renderers to isolate orchestrator behavior
+vi.mock("../../src/detail/renderDeclensionTable.js", () => ({
+    renderDeclensionTable: () => {
+        const c = document.getElementById("inflections-container");
+        if (c) {
+            c.replaceChildren();
+            const marker = document.createElement("div");
+            marker.id = "declension-marker";
+            marker.textContent = "DECL";
+            c.appendChild(marker);
+        }
+    },
+}));
+
+vi.mock("../../src/detail/renderConjugationTable.js", () => ({
+    renderConjugationTable: () => {
+        const c = document.getElementById("inflections-container");
+        if (c) {
+            c.replaceChildren();
+            const marker = document.createElement("div");
+            marker.id = "conjugation-marker";
+            marker.textContent = "CONJ";
+            c.appendChild(marker);
+        }
+    },
+}));
+
+vi.mock("../../src/detail/renderAdjectiveAgreementTable.js", () => ({
+    renderAdjectiveAgreementTable: () => {
+        const c = document.getElementById("inflections-container");
+        if (c) {
+            c.replaceChildren();
+            const marker = document.createElement("div");
+            marker.id = "agreement-marker";
+            marker.textContent = "AGRM";
+            c.appendChild(marker);
+        }
+    },
+}));
+
+// Keep these real to verify their own clearing logic as part of flows
+vi.mock("../../src/detail/renderLemmaHeader.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderDefinitions.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderInflectionType.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderPrincipalParts.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderAdverbSpecificElements.js", async (orig) => await orig());
+
+import { renderWordDetail } from "../../src/detail/renderWordDetail.js";
+
+function setupDom() {
+    document.body.innerHTML = `
+    <div id="lemma-container"></div>
+    <div id="definitions-container"></div>
+    <div id="principal-parts-container"></div>
+    <div id="inflection-type-container"></div>
+    <div id="inflections-container"></div>
+  `;
+}
+
+describe("renderWordDetail clearing/orchestration behavior (with markers)", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        setupDom();
+    });
+
+    it("clears inflections for an adverb, then renders declension only for a noun", () => {
+        const adverb = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: ["well"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+        renderWordDetail(adverb);
+        const inflectionsAfterAdverb = document.getElementById("inflections-container");
+        expect(inflectionsAfterAdverb.childElementCount).toBe(0);
+
+        const noun = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: {
+                conjugations: [{ voice: "ACTIVE" }],
+                agreements: [{}],
+                declensions: { SINGULAR: { NOMINATIVE: "puella" }, PLURAL: { NOMINATIVE: "puellae" } },
+            },
+        };
+        renderWordDetail(noun);
+        const inflectionsAfterNoun = document.getElementById("inflections-container");
+        expect(inflectionsAfterNoun.querySelector("#declension-marker")).toBeTruthy();
+        expect(inflectionsAfterNoun.querySelector("#conjugation-marker")).toBeFalsy();
+        expect(inflectionsAfterNoun.querySelector("#agreement-marker")).toBeFalsy();
+    });
+
+    it("switching from noun to verb replaces the previous inflection table content", () => {
+        const noun = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: {
+                conjugations: [{ voice: "ACTIVE" }],
+                agreements: [{}],
+                declensions: { SINGULAR: { NOMINATIVE: "puella" }, PLURAL: { NOMINATIVE: "puellae" } },
+            },
+        };
+        renderWordDetail(noun);
+        expect(document.querySelector("#declension-marker")).toBeTruthy();
+
+        const verb = {
+            lemma: "amo",
+            position: "VERB",
+            grammaticalGender: null,
+            inflectionClass: "FIRST",
+            principalParts: ["amo", "amare", "amavi", "amatum"],
+            definitions: ["love"],
+            inflectionTable: { conjugations: [{ voice: "ACTIVE" }], agreements: [], declensions: {} },
+        };
+        renderWordDetail(verb);
+        expect(document.querySelector("#conjugation-marker")).toBeTruthy();
+        expect(document.querySelector("#declension-marker")).toBeFalsy();
+        expect(document.querySelector("#agreement-marker")).toBeFalsy();
+    });
+
+    it("principal parts container reflects only latest data (cleared when empty)", () => {
+        const first = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: { SINGULAR: {}, PLURAL: {} } },
+        };
+        renderWordDetail(first);
+        expect(document.getElementById("principal-parts-container").textContent)
+            .toMatch(/puella, puellae/);
+
+        const second = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: ["well"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+        renderWordDetail(second);
+        expect(document.getElementById("principal-parts-container").textContent.trim()).toBe("");
+    });
+
+    it("inflections area is empty for POS without inflection tables", () => {
+        const data = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: ["well"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+        renderWordDetail(data);
+        expect(document.getElementById("inflections-container").childElementCount).toBe(0);
+    });
+});

--- a/test/detail/renderer.clearing.integration.test.js
+++ b/test/detail/renderer.clearing.integration.test.js
@@ -1,0 +1,160 @@
+
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Use real implementations
+vi.mock("../../src/detail/renderDeclensionTable.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderConjugationTable.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderAdjectiveAgreementTable.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderLemmaHeader.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderDefinitions.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderInflectionType.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderPrincipalParts.js", async (orig) => await orig());
+vi.mock("../../src/detail/renderAdverbSpecificElements.js", async (orig) => await orig());
+
+import { renderWordDetail } from "../../src/detail/renderWordDetail.js";
+
+function setupDom() {
+    document.body.innerHTML = `
+    <div id="lemma-container"></div>
+    <div id="definitions-container"></div>
+    <div id="principal-parts-container"></div>
+    <div id="inflection-type-container"></div>
+    <div id="inflections-container"></div>
+  `;
+}
+
+describe("Integration: real renderers clear correctly", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        setupDom();
+    });
+
+    it("switching POS replaces the table content (declension -> conjugation)", () => {
+        const noun = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: {
+                conjugations: [{ voice: "ACTIVE" }],
+                agreements: [{}],
+                declensions: { SINGULAR: { NOMINATIVE: "puella" }, PLURAL: { NOMINATIVE: "puellae" } },
+            },
+        };
+        renderWordDetail(noun);
+        const afterNounHTML = document.getElementById("inflections-container").innerHTML;
+        expect(afterNounHTML).toContain("declension-table");
+
+        const verb = {
+            lemma: "amo",
+            position: "VERB",
+            grammaticalGender: null,
+            inflectionClass: "FIRST",
+            principalParts: ["amo", "amare", "amavi", "amatum"],
+            definitions: ["love"],
+            inflectionTable: { conjugations: [{ voice: "ACTIVE" }], agreements: [], declensions: {} },
+        };
+        renderWordDetail(verb);
+        const afterVerbHTML = document.getElementById("inflections-container").innerHTML;
+        expect(afterVerbHTML).toContain("conjugation-table");
+        expect(afterVerbHTML).not.toContain("declension-table");
+    });
+
+    it("principal parts clear when none provided on next render", () => {
+        const withParts = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: { SINGULAR: {}, PLURAL: {} } },
+        };
+        renderWordDetail(withParts);
+        expect(document.getElementById("principal-parts-container").textContent)
+            .toMatch(/puella, puellae/);
+
+        const noParts = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: ["well"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+        renderWordDetail(noParts);
+        expect(document.getElementById("principal-parts-container").textContent.trim()).toBe("");
+    });
+
+    it("inflection-type container is cleared each time and shows POS only for configured types", () => {
+        const noun = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: [],
+            definitions: [],
+            inflectionTable: { conjugations: [], agreements: [], declensions: { SINGULAR: {}, PLURAL: {} } },
+        };
+        renderWordDetail(noun);
+        const inflectionTypeAfterNoun = document.getElementById("inflection-type-container").textContent;
+        expect(inflectionTypeAfterNoun).toMatch(/\(noun\)/i);
+
+        const adverb = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: [],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+        renderWordDetail(adverb);
+        const inflectionTypeAfterAdverb = document.getElementById("inflection-type-container").textContent;
+        // should not include grammatical-position for adverb (rendered elsewhere)
+        expect(inflectionTypeAfterAdverb.toLowerCase()).not.toMatch(/\(adverb\)/);
+    });
+
+    it("adds POS badge to lemma-container for ADVERB and removes it for a subsequent non-adverb", () => {
+        const adverb = {
+            lemma: "bene",
+            position: "ADVERB",
+            grammaticalGender: null,
+            inflectionClass: null,
+            principalParts: [],
+            definitions: ["well"],
+            inflectionTable: { conjugations: [], agreements: [], declensions: {} },
+        };
+
+        renderWordDetail(adverb);
+
+        const lemmaContainerAfterAdverb = document.getElementById("lemma-container");
+        const adverbBadge = lemmaContainerAfterAdverb.querySelector(".grammatical-position");
+        expect(adverbBadge).toBeTruthy();
+
+        const noun = {
+            lemma: "puella",
+            position: "NOUN",
+            grammaticalGender: "FEMININE",
+            inflectionClass: "FIRST",
+            principalParts: ["puella", "puellae"],
+            definitions: ["girl"],
+            inflectionTable: {
+                conjugations: [{ voice: "ACTIVE" }],
+                agreements: [{}],
+                declensions: { SINGULAR: { NOMINATIVE: "puella" }, PLURAL: { NOMINATIVE: "puellae" } },
+            },
+        };
+
+        renderWordDetail(noun);
+
+        const lemmaContainerAfterNoun = document.getElementById("lemma-container");
+        const nounBadge = lemmaContainerAfterNoun.querySelector(".grammatical-position");
+        expect(nounBadge).toBeFalsy();
+    });
+
+});

--- a/test/search/handleWordLookup.test.js
+++ b/test/search/handleWordLookup.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { handleWordLookup } from "@search";
+
+describe("handleWordLookup", () => {
+  const fetchMock = async (query) => {
+    // Mock API results
+    if (query === "apple") return ["Apple", "Applet", "Applejack"];
+    return [];
+  };
+
+  it("returns suggestions for a valid query", async () => {
+    const result = await handleWordLookup("apple", fetchMock, 3);
+
+    expect(result.status).toBe("success");
+    // Order-insensitive check + ensure exact cardinality
+    expect(result.data).toEqual(
+      expect.arrayContaining(["Apple", "Applet", "Applejack"]),
+    );
+    expect(result.data).toHaveLength(3);
+  });
+
+  it("handles empty suggestions", async () => {
+    const result = await handleWordLookup("banana", fetchMock, 3);
+
+    expect(result).toEqual({
+      status: "error",
+      message: "No suggestions found",
+    });
+  });
+
+  it("returns an error for fetch failures", async () => {
+    const errorFetchMock = async () => {
+      throw new Error("Network failure");
+    };
+
+    const result = await handleWordLookup("apple", errorFetchMock, 3);
+
+    expect(result).toEqual({
+      status: "error",
+      message:
+        "We're having trouble fetching suggestions right now. Please try again later.",
+    });
+  });
+});

--- a/test/search/transformWordSuggestionData.test.js
+++ b/test/search/transformWordSuggestionData.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { transformWordSuggestionData } from "@search";
+
+describe("transformWordSuggestionData", () => {
+  it("transforms valid word data into display-friendly format", () => {
+    const words = [
+      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
+      { word: "runner", lexemeId: 2, grammaticalPosition: "NOUN" },
+    ];
+
+    const result = transformWordSuggestionData(words);
+
+    expect(result).toEqual([
+      { word: "run", lexemeId: 1, suggestion: "run (vrb)" },
+      { word: "runner", lexemeId: 2, suggestion: "runner (nom)" },
+    ]);
+  });
+  it("transforms an unknown partOfSpeech to a lowercase string ", () => {
+    const words = [
+      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
+      { word: "runner", lexemeId: 2, grammaticalPosition: "random" },
+    ];
+
+    const result = transformWordSuggestionData(words);
+
+    expect(result).toEqual([
+      { word: "run", lexemeId: 1, suggestion: "run (vrb)" },
+      { word: "runner", lexemeId: 2, suggestion: "runner (random)" },
+    ]);
+  });
+
+  it("filters out word data with empty word field", () => {
+    const words = [
+      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
+      { word: "", lexemeId: 2, grammaticalPosition: "NOUN" },
+    ];
+
+    const result = transformWordSuggestionData(words);
+
+    expect(result).toEqual([
+      { word: "run", lexemeId: 1, suggestion: "run (vrb)" },
+    ]);
+  });
+  it("filters out word data with empty id field", () => {
+    const words = [
+      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
+      { word: "runner", lexemeId: "", grammaticalPosition: "NOUN" },
+    ];
+
+    const result = transformWordSuggestionData(words);
+
+    expect(result).toEqual([
+      { word: "run", lexemeId: 1, suggestion: "run (vrb)" },
+    ]);
+  });
+  it("filters out word data with empty suggestion field", () => {
+    const words = [
+      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
+      { word: "runner", lexemeId: "", grammaticalPosition: "" },
+    ];
+
+    const result = transformWordSuggestionData(words);
+
+    expect(result).toEqual([
+      { word: "run", lexemeId: 1, suggestion: "run (vrb)" },
+    ]);
+  });
+});

--- a/test/search/validateQuery.test.js
+++ b/test/search/validateQuery.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { validateQuery } from "@search";
+
+describe("validateQuery", () => {
+  it("returns the trimmed query if it meets the minimum length", () => {
+    const result = validateQuery(" apple ", 3);
+    expect(result).toBe("apple");
+  });
+
+  it("returns null for a query shorter than the minimum length", () => {
+    const result = validateQuery("ap", 3);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a query with only whitespace", () => {
+    const result = validateQuery("   ", 3);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION

Summary
- Extracted rendering responsibilities into focused modules under src/detail to reduce coupling and make rendering idempotent and testable.
- Standardized container clearing to renderer-owned logic, using replaceChildren where appropriate.
- Hardened edge cases (e.g., missing inflectionTable, verb conjugations without tenses).
- Added comprehensive tests for detail rendering orchestration and integration, plus search flow behavior.
- Aligned tests with current return shapes and error-handling semantics.

Why
- The previous “clear in orchestrator” approach caused incidental coupling, flicker risk, and ordering bugs (e.g., one renderer clearing another’s work).
- Splitting by responsibility and making each renderer own its container clearing yields predictable, idempotent behavior and simpler tests.
- Tests now cover both orchestration decisions and real renderer DOM updates, preventing regressions during future POS/feature additions.
