### PR TITLE
Refactor: rename `grammaticalPosition` to `partOfSpeech` across codebase

### DIFF
--- a/src/detail/renderAdverbSpecificElements.js
+++ b/src/detail/renderAdverbSpecificElements.js
@@ -9,11 +9,11 @@ export function renderAdverbSpecificContent(partOfSpeech){
     if (!container) return;
 
     //  remove only prior adverb marker(s) not the whole lemma-header
-    container.querySelectorAll(".grammatical-position").forEach(n => n.remove());
+    container.querySelectorAll(".part-of-speech").forEach(n => n.remove());
 
-    const positionSpan = document.createElement("span");
-    positionSpan.classList.add("grammatical-position");
-    positionSpan.textContent = `  (${formatPOS(partOfSpeech)})`;
+    const partOfSpeechSpan = document.createElement("span");
+    partOfSpeechSpan.classList.add("part-of-speech");
+    partOfSpeechSpan.textContent = `  (${formatPOS(partOfSpeech)})`;
 
-    container.appendChild(positionSpan);
+    container.appendChild(partOfSpeechSpan);
 }

--- a/src/detail/renderInflectionType.js
+++ b/src/detail/renderInflectionType.js
@@ -19,9 +19,9 @@ export function renderInflectionType(inflectionClass, partOfSpeech) {
   const POS_POSITION_IN_INFLECTION = new Set(["noun", "verb", "adjective"]);
 
   if (posLower && POS_POSITION_IN_INFLECTION.has(posLower)) {
-    const positionSpan = document.createElement("span");
-    positionSpan.classList.add("grammatical-position");
-    positionSpan.textContent = ` (${posLower})`;
-    container.appendChild(positionSpan);
+    const partOfSpeechSpan = document.createElement("span");
+    partOfSpeechSpan.classList.add("part-of-speech");
+    partOfSpeechSpan.textContent = ` (${posLower})`;
+    container.appendChild(partOfSpeechSpan);
   }
 }

--- a/src/detail/renderWordDetail.js
+++ b/src/detail/renderWordDetail.js
@@ -19,7 +19,7 @@ import {renderAdverbSpecificContent} from "@detail/renderAdverbSpecificElements.
 export function renderWordDetail(wordDetailData) {
     const {
         lemma,
-        position: partOfSpeech,
+        partOfSpeech,
         grammaticalGender: gender,
         inflectionClass,
         principalParts,

--- a/src/search/transformWordSuggestionData.js
+++ b/src/search/transformWordSuggestionData.js
@@ -4,10 +4,7 @@ export function transformWordSuggestionData(wordSuggestionData) {
   return wordSuggestionData
     .map((suggestionDatum) => {
       const {
-        word,
-        lexemeId,
-        grammaticalPosition: partOfSpeech,
-      } = suggestionDatum;
+        word, lexemeId, partOfSpeech, } = suggestionDatum;
       let suggestion;
 
       if (word && partOfSpeech && lexemeId) {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -128,7 +128,7 @@ label {
     font-weight: bold;
 }
 
-.grammatical-position {
+.part-of-speech {
     color: var(--color-brand-primary);
     font-size: 1rem;
     margin-right: 0.5em;

--- a/test/detail/renderWordDetail.clearing.test.js
+++ b/test/detail/renderWordDetail.clearing.test.js
@@ -69,7 +69,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
     it("clears inflections for an adverb, then renders declension only for a noun", () => {
         const adverb = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],
@@ -82,7 +82,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
 
         const noun = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -103,7 +103,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
     it("switching from noun to verb replaces the previous inflection table content", () => {
         const noun = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -119,7 +119,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
 
         const verb = {
             lemma: "amo",
-            position: "VERB",
+            partOfSpeech: "VERB",
             grammaticalGender: null,
             inflectionClass: "FIRST",
             principalParts: ["amo", "amare", "amavi", "amatum"],
@@ -135,7 +135,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
     it("principal parts container reflects only latest data (cleared when empty)", () => {
         const first = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -148,7 +148,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
 
         const second = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],
@@ -162,7 +162,7 @@ describe("renderWordDetail clearing/orchestration behavior (with markers)", () =
     it("inflections area is empty for POS without inflection tables", () => {
         const data = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],

--- a/test/detail/renderer.clearing.integration.test.js
+++ b/test/detail/renderer.clearing.integration.test.js
@@ -33,7 +33,7 @@ describe("Integration: real renderers clear correctly", () => {
     it("switching POS replaces the table content (declension -> conjugation)", () => {
         const noun = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -50,7 +50,7 @@ describe("Integration: real renderers clear correctly", () => {
 
         const verb = {
             lemma: "amo",
-            position: "VERB",
+            partOfSpeech: "VERB",
             grammaticalGender: null,
             inflectionClass: "FIRST",
             principalParts: ["amo", "amare", "amavi", "amatum"],
@@ -66,7 +66,7 @@ describe("Integration: real renderers clear correctly", () => {
     it("principal parts clear when none provided on next render", () => {
         const withParts = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -79,7 +79,7 @@ describe("Integration: real renderers clear correctly", () => {
 
         const noParts = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],
@@ -93,7 +93,7 @@ describe("Integration: real renderers clear correctly", () => {
     it("inflection-type container is cleared each time and shows POS only for configured types", () => {
         const noun = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: [],
@@ -106,7 +106,7 @@ describe("Integration: real renderers clear correctly", () => {
 
         const adverb = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],
@@ -115,14 +115,14 @@ describe("Integration: real renderers clear correctly", () => {
         };
         renderWordDetail(adverb);
         const inflectionTypeAfterAdverb = document.getElementById("inflection-type-container").textContent;
-        // should not include grammatical-position for adverb (rendered elsewhere)
+        // should not include part-of-speech for adverb (rendered elsewhere)
         expect(inflectionTypeAfterAdverb.toLowerCase()).not.toMatch(/\(adverb\)/);
     });
 
     it("adds POS badge to lemma-container for ADVERB and removes it for a subsequent non-adverb", () => {
         const adverb = {
             lemma: "bene",
-            position: "ADVERB",
+            partOfSpeech: "ADVERB",
             grammaticalGender: null,
             inflectionClass: null,
             principalParts: [],
@@ -133,12 +133,12 @@ describe("Integration: real renderers clear correctly", () => {
         renderWordDetail(adverb);
 
         const lemmaContainerAfterAdverb = document.getElementById("lemma-container");
-        const adverbBadge = lemmaContainerAfterAdverb.querySelector(".grammatical-position");
+        const adverbBadge = lemmaContainerAfterAdverb.querySelector(".part-of-speech");
         expect(adverbBadge).toBeTruthy();
 
         const noun = {
             lemma: "puella",
-            position: "NOUN",
+            partOfSpeech: "NOUN",
             grammaticalGender: "FEMININE",
             inflectionClass: "FIRST",
             principalParts: ["puella", "puellae"],
@@ -153,7 +153,7 @@ describe("Integration: real renderers clear correctly", () => {
         renderWordDetail(noun);
 
         const lemmaContainerAfterNoun = document.getElementById("lemma-container");
-        const nounBadge = lemmaContainerAfterNoun.querySelector(".grammatical-position");
+        const nounBadge = lemmaContainerAfterNoun.querySelector(".part-of-speech");
         expect(nounBadge).toBeFalsy();
     });
 

--- a/test/search/transformWordSuggestionData.test.js
+++ b/test/search/transformWordSuggestionData.test.js
@@ -4,8 +4,8 @@ import { transformWordSuggestionData } from "@search";
 describe("transformWordSuggestionData", () => {
   it("transforms valid word data into display-friendly format", () => {
     const words = [
-      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
-      { word: "runner", lexemeId: 2, grammaticalPosition: "NOUN" },
+      { word: "run", lexemeId: 1, partOfSpeech: "VERB" },
+      { word: "runner", lexemeId: 2, partOfSpeech: "NOUN" },
     ];
 
     const result = transformWordSuggestionData(words);
@@ -17,8 +17,8 @@ describe("transformWordSuggestionData", () => {
   });
   it("transforms an unknown partOfSpeech to a lowercase string ", () => {
     const words = [
-      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
-      { word: "runner", lexemeId: 2, grammaticalPosition: "random" },
+      { word: "run", lexemeId: 1, partOfSpeech: "VERB" },
+      { word: "runner", lexemeId: 2, partOfSpeech: "random" },
     ];
 
     const result = transformWordSuggestionData(words);
@@ -31,8 +31,8 @@ describe("transformWordSuggestionData", () => {
 
   it("filters out word data with empty word field", () => {
     const words = [
-      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
-      { word: "", lexemeId: 2, grammaticalPosition: "NOUN" },
+      { word: "run", lexemeId: 1, partOfSpeech: "VERB" },
+      { word: "", lexemeId: 2, partOfSpeech: "NOUN" },
     ];
 
     const result = transformWordSuggestionData(words);
@@ -43,8 +43,8 @@ describe("transformWordSuggestionData", () => {
   });
   it("filters out word data with empty id field", () => {
     const words = [
-      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
-      { word: "runner", lexemeId: "", grammaticalPosition: "NOUN" },
+      { word: "run", lexemeId: 1, partOfSpeech: "VERB" },
+      { word: "runner", lexemeId: "", partOfSpeech: "NOUN" },
     ];
 
     const result = transformWordSuggestionData(words);
@@ -55,8 +55,8 @@ describe("transformWordSuggestionData", () => {
   });
   it("filters out word data with empty suggestion field", () => {
     const words = [
-      { word: "run", lexemeId: 1, grammaticalPosition: "VERB" },
-      { word: "runner", lexemeId: "", grammaticalPosition: "" },
+      { word: "run", lexemeId: 1, partOfSpeech: "VERB" },
+      { word: "runner", lexemeId: "", partOfSpeech: "" },
     ];
 
     const result = transformWordSuggestionData(words);


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- Renames `grammaticalPosition` field to `partOfSpeech` for compatibility with the upstream API schema.
- Updates class names, functions, and selectors to reflect the new terminology.
- Adjusts related test cases and expected outputs.
- Ensures consistent application across rendering functions, styles, and test cases.

### Checklist

- [X ] The changes pass all tests.
- [ X] Documentation has been updated corresponding to these changes, if necessary.

### Additional Notes

This is a breaking change; therefore, downstream consumers should align with the updated schema.