### PR TITLE
Add support for conjunctions in POS handling and rendering

### DIFF
--- a/src/detail/renderPOSAfterLemma.js
+++ b/src/detail/renderPOSAfterLemma.js
@@ -1,7 +1,9 @@
 import {abbrevPartOfSpeech} from "@src/utils/formatPartOfSpeech.js";
 
 export function renderPOSAfterLemma(partOfSpeech){
-    if (partOfSpeech !== "ADVERB" && partOfSpeech !== "PREPOSITION" !== "POSTPOSITION") {
+    const positionsToRender = ["ADVERB", "PREPOSITION", "POSTPOSITION", "CONJUNCTION"];
+    
+    if (!positionsToRender.includes(partOfSpeech)) {
         return; 
     }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,22 +3,24 @@ export const QUERY_CHAR_MIN = 1;
 
 //Parts of Speech
 export const POS = Object.freeze({
-    NOUN: "NOUN",
-    VERB: "VERB",
     ADJECTIVE: "ADJECTIVE",
     ADVERB: "ADVERB",
+    CONJUNCTION: "CONJUNCTION",
+    NOUN: "NOUN",
     PREPOSITION: "PREPOSITION",
-    POSTPOSITION: "POSTPOSITION"
+    POSTPOSITION: "POSTPOSITION",
+    VERB: "VERB",
 });
 
 
 export const POS_ABBREV_LABEL = Object.freeze({
-    [POS.NOUN]: "nom",
-    [POS.VERB]: "vrb",
     [POS.ADVERB]: "adv",
     [POS.ADJECTIVE]: "adj",
+    [POS.CONJUNCTION]: "conj",
+    [POS.NOUN]: "nom",
     [POS.PREPOSITION]: "prep",
-        [POS.POSTPOSITION]: "postp",
+    [POS.POSTPOSITION]: "postp",
+    [POS.VERB]: "vrb",
 });
 
 export const POS_KEYS = Object.freeze(Object.keys(POS_ABBREV_LABEL));


### PR DESCRIPTION
- **What does this implement/fix? Explain your changes.**  
  This pull request adds support for conjunctions in part-of-speech (POS) handling and rendering by extending `POS` and `POS_ABBREV_LABEL` with `CONJUNCTION`. It also updates `renderPOSAfterLemma` to incorporate conjunctions into the rendering logic.


