### PR TITLE
Add support for determiners and pronouns in POS handling

### DIFF
--- a/src/detail/renderDefinitions.js
+++ b/src/detail/renderDefinitions.js
@@ -1,6 +1,8 @@
-import { renderPrepositionSpecificElements } from "./renderPrepositionSpecificElements.js";
+import { renderPrepositionSpecificElements } from "@detail/renderPrepositionSpecificElements.js";
+import { renderSubtypeSpecificElements } from "@detail/renderSubtypeSpecificElements.js";
+import {POS} from "@src/utils/constants.js";
 
-export function renderDefinitions(definitions, governedCase, partOfSpeech) {
+export function renderDefinitions(definitions, governedCase, partOfSpeech, subtype) {
   const container = document.getElementById("definitions-container");
   container.replaceChildren();
 
@@ -9,10 +11,18 @@ export function renderDefinitions(definitions, governedCase, partOfSpeech) {
   definitionsLabelSpan.textContent = "Definitions:";
   container.appendChild(definitionsLabelSpan);
 
+   let senseSpecificContent;
   // Insert preposition-specific content (e.g., governedCase) between the label and the lists
-  const prepositionContentNode = renderPrepositionSpecificElements?.(governedCase, partOfSpeech);
-  if (prepositionContentNode) {
-    container.appendChild(prepositionContentNode);
+    if(partOfSpeech == POS.PREPOSITION ||partOfSpeech ==  POS.POSTPOSITION){
+        senseSpecificContent = renderPrepositionSpecificElements?.(governedCase, partOfSpeech);
+    }
+    // Insert subtype-specific content (e.g., subtype) between the label and the lists
+    else if (partOfSpeech == POS.DETERMINER || partOfSpeech == POS.PRONOUN) {
+        senseSpecificContent = renderSubtypeSpecificElements?.(subtype, partOfSpeech);
+    }
+
+  if (senseSpecificContent) {
+      container.appendChild(senseSpecificContent);
   }
 
   if (!definitions || definitions.length === 0) return;

--- a/src/detail/renderInflectionType.js
+++ b/src/detail/renderInflectionType.js
@@ -1,3 +1,5 @@
+import {POS} from "@src/utils/constants.js";
+
 export function renderInflectionType(inflectionClass, partOfSpeech) {
   let container = document.getElementById("inflection-type-container");
 
@@ -16,9 +18,10 @@ export function renderInflectionType(inflectionClass, partOfSpeech) {
 
   // Set of POS types that have inflection info (such as an inflection table)
   // above which it makes sense to add the POS info
-  const POS_POSITION_IN_INFLECTION = new Set(["noun", "verb", "adjective"]);
 
-  if (posLower && POS_POSITION_IN_INFLECTION.has(posLower)) {
+  const POS_POSITION_IN_INFLECTION = new Set([ POS.ADJECTIVE, POS.NOUN, POS.VERB]);
+
+  if (posRaw && POS_POSITION_IN_INFLECTION.has(posRaw)) {
     const partOfSpeechSpan = document.createElement("span");
     partOfSpeechSpan.classList.add("part-of-speech");
     partOfSpeechSpan.textContent = ` (${posLower})`;

--- a/src/detail/renderPOSAfterLemma.js
+++ b/src/detail/renderPOSAfterLemma.js
@@ -1,8 +1,10 @@
 import {abbrevPartOfSpeech} from "@src/utils/formatPartOfSpeech.js";
+import {POS} from "@src/utils/constants.js";
 
 export function renderPOSAfterLemma(partOfSpeech){
-    const positionsToRender = ["ADVERB", "PREPOSITION", "POSTPOSITION", "CONJUNCTION"];
-    
+
+        const positionsToRender = [POS.ADVERB, POS.PREPOSITION, POS.POSTPOSITION, POS.CONJUNCTION];
+
     if (!positionsToRender.includes(partOfSpeech)) {
         return; 
     }

--- a/src/detail/renderPrepositionSpecificElements.js
+++ b/src/detail/renderPrepositionSpecificElements.js
@@ -8,7 +8,7 @@ export function renderPrepositionSpecificElements(governedCase, partOfSpeech){
     }
     const formattedCase = governedCase
     const governedCaseSpan = document.createElement("span");
-    governedCaseSpan.classList.add("governed-case");
+    governedCaseSpan.classList.add("definition-subheader");
     governedCaseSpan.textContent = `${formatPOSForDefinitions(partOfSpeech)} with ${governedCase.toLowerCase()}:`;
 
     return governedCaseSpan;

--- a/src/detail/renderSubtypeSpecificElements.js
+++ b/src/detail/renderSubtypeSpecificElements.js
@@ -1,0 +1,15 @@
+import {formatPOSForDefinitions, parsePartOfSpeech} from "@src/utils/formatPartOfSpeech.js";
+import {POS} from "@src/utils/constants.js";
+
+export function renderSubtypeSpecificElements(subtype, partOfSpeech){
+    const pos = parsePartOfSpeech(partOfSpeech)
+    if ( subtype == null) {
+        return;
+    }
+    const formattedCase = subtype
+    const subtypeSpan = document.createElement("span");
+    subtypeSpan.classList.add("definition-subheader");
+    subtypeSpan.textContent = ` ${formatPOSForDefinitions(subtype)} ${formatPOSForDefinitions(partOfSpeech)}:`;
+
+    return subtypeSpan;
+}

--- a/src/detail/renderWordDetail.js
+++ b/src/detail/renderWordDetail.js
@@ -20,6 +20,7 @@ export function renderWordDetail(wordDetailData) {
     const {
         lemma,
         partOfSpeech,
+        syntacticSubtype: subtype,
         grammaticalGender: gender,
         governedCase,
         inflectionClass,
@@ -29,7 +30,7 @@ export function renderWordDetail(wordDetailData) {
 
     try {
         renderLemmaHeader(lemma);
-        renderDefinitions(definitions, governedCase, partOfSpeech);
+        renderDefinitions(definitions, governedCase, partOfSpeech, subtype);
 
         renderPOSAfterLemma(partOfSpeech);
         renderPrincipalParts(principalParts);
@@ -55,7 +56,7 @@ export function renderWordDetail(wordDetailData) {
             renderDeclensionTable(declensions);
         } else if (pos === "VERB") {
             renderConjugationTable(conjugations, "ACTIVE");
-        } else if (pos === "ADJECTIVE") {
+        } else if (pos === "ADJECTIVE" || pos === "DETERMINER" || pos === "PRONOUN") {
             renderAdjectiveAgreementTable(agreements);
         } else {
             // No inflections for this POS; ensure area is cleared

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -175,7 +175,7 @@ label {
     padding: 0;
 }
 
-.governed-case {
+.definition-subheader {
     display: block;
     margin-top: 1rem;
     font-size: 0.95rem;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,9 +6,11 @@ export const POS = Object.freeze({
     ADJECTIVE: "ADJECTIVE",
     ADVERB: "ADVERB",
     CONJUNCTION: "CONJUNCTION",
+    DETERMINER: "DETERMINER",
     NOUN: "NOUN",
     PREPOSITION: "PREPOSITION",
     POSTPOSITION: "POSTPOSITION",
+    PRONOUN: "PRONOUN",
     VERB: "VERB",
 });
 
@@ -17,9 +19,11 @@ export const POS_ABBREV_LABEL = Object.freeze({
     [POS.ADVERB]: "adv",
     [POS.ADJECTIVE]: "adj",
     [POS.CONJUNCTION]: "conj",
+    [POS.DETERMINER]: "pron adj",
     [POS.NOUN]: "nom",
     [POS.PREPOSITION]: "prep",
     [POS.POSTPOSITION]: "postp",
+    [POS.PRONOUN]: "pronom",
     [POS.VERB]: "vrb",
 });
 


### PR DESCRIPTION
- Extend `POS` and `POS_ABBREV_LABEL` with `DETERMINER` and `PRONOUN`.
- Enhance `renderDefinitions` to manage subtype-specific content for determiners and pronouns.
- Add `renderSubtypeSpecificElements` to support rendering logic for these subtypes.
- Update accompanying CSS for definition subheaders styling and repurposing.
- Refactor `renderPOSAfterLemma` and `renderInflectionType` for alignment with the new POS enhancements.