### PR TITLE
Add query normalization for case-insensitive searching

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,12 @@
 import "./styles/index.css";
 import {QUERY_CHAR_MIN, AUTOCOMPLETE_DEBOUNCE_MS, STATUS_TOAST_DURATION, StatusMessageType} from "@utilities/constants"
 import {fetchWordSuggestions} from "@api";
-import {handleWordLookup} from  "@search";
+import {handleWordLookup} from "@search";
 import {prepareSuggestionItems} from "@search";
 import {validateSearchQueryLength} from "@search";
-import {transformWordSuggestionData} from  "@search";
+import {transformWordSuggestionData} from "@search";
 import {handleLoadWordDetail} from "@detail";
+import {normalizeSearchQuery} from "@search/validate.js";
 
 const isSuffixSearch = document.querySelector("#suffix-search");
 const wordLookupInput = document.querySelector("#word-lookup-input");
@@ -42,17 +43,20 @@ function hideSuggestions() {
  */
 wordLookupInput.addEventListener("input", async () => {
     const searchWord = wordLookupInput.value;
-    const query = validateSearchQueryLength(searchWord, QUERY_CHAR_MIN);
+    const validatedQuery = validateSearchQueryLength(searchWord, QUERY_CHAR_MIN);
 
     // Clear any pending debounce
     if (debounceTimer) {
         clearTimeout(debounceTimer);
     }
 
-    if (!query) {
+    if (!validatedQuery) {
         hideSuggestions();
         return;
     }
+
+    const normalizedQuery = normalizeSearchQuery(validatedQuery);
+
     debounceTimer = setTimeout(async () => {
         // race condition tracking
         const requestId = ++currentRequestId;
@@ -60,7 +64,7 @@ wordLookupInput.addEventListener("input", async () => {
         // Clear while loading
         wordSuggestionsBox.replaceChildren();
 
-        const result = await handleWordLookup(query, fetchWordSuggestions, isSuffixSearch.checked);
+        const result = await handleWordLookup(normalizedQuery, fetchWordSuggestions, isSuffixSearch.checked);
 
         // Ignore stale responses
         if (requestId !== currentRequestId) {
@@ -137,7 +141,7 @@ export function renderWordSuggestionBox(
 
     wordSuggestionsBox.style.display = "block";
 
-   // Build the drop-down list
+    // Build the drop-down list
     for (const {word, lexemeId, display, highlight, showInflection} of preparedItems) {
         const item = document.createElement("div");
         if (highlight) {
@@ -198,7 +202,6 @@ export function renderWordSuggestionBox(
         wordSuggestionsBox.style.overflowY = totalHeight > snappedHeight ? "auto" : "hidden";
     });
 }
-
 
 
 /**

--- a/src/search/validate.js
+++ b/src/search/validate.js
@@ -1,4 +1,8 @@
 export function validateSearchQueryLength(query, minQueryLength) {
-  const trimmedQuery = query.trim();
-  return trimmedQuery.length >= minQueryLength ? trimmedQuery : undefined;
+    const trimmedQuery = query.trim();
+    return trimmedQuery.length >= minQueryLength ? trimmedQuery : undefined;
+}
+
+export function normalizeSearchQuery(query) {
+    return query.trim().toLowerCase();
 }

--- a/test/app/input-event-listener.test.js
+++ b/test/app/input-event-listener.test.js
@@ -1,0 +1,42 @@
+/* @vitest-environment jsdom */
+import {describe, it, expect, beforeAll, afterEach, vi} from "vitest";
+import {readFileSync} from "node:fs";
+import path from "node:path";
+
+vi.mock("@search", async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        handleWordLookup: vi.fn(),
+    };
+});
+
+describe("wordLookupInput event listener", () => {
+    let handleWordLookup;
+
+    beforeAll(async () => {
+        const html = readFileSync(path.resolve(process.cwd(), "index.html"), "utf8");
+        const match = html.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+        document.body.innerHTML = match ? match[1] : "";
+        await import("../../src/main.js");
+        ({handleWordLookup} = await import("@search"));
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.useRealTimers();
+    });
+
+    it("passes lowercased query to handleWordLookup", async () => {
+        vi.useFakeTimers();
+
+        handleWordLookup.mockResolvedValue({status: "success", data: []});
+        const input = document.querySelector("#word-lookup-input");
+        input.value = "AMOR";
+        input.dispatchEvent(new Event("input"));
+
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(handleWordLookup).toHaveBeenCalledWith("amor", expect.any(Function), false);
+    });
+});


### PR DESCRIPTION
- Introduced `normalizeSearchQuery` to ensure all search queries are processed in lowercase, addressing case sensitivity issues.
- Added a corresponding unit test to verify that `wordLookupInput` normalizes queries before passing them to `handleWordLookup`.