### PR TITLE
fix(definitions): fix indentation and hide redundant show-more toggle

### DIFF
--- a/docs/planning/handle-new-definitions-response-data-structure.md
+++ b/docs/planning/handle-new-definitions-response-data-structure.md
@@ -123,3 +123,48 @@ didn't bother adding it to below example. But it should only be numbered if ther
         3. loud, powerful, strong, mighty (of voice)
 ```
 
+## Issue Found
+
+Currently, the 'show more' link appears regardless of whether there are multiple definitions.
+
+Ex: definition for noun 'raeda':
+There is only one definition in the definitions array
+
+```json
+{
+  "definitions": [
+    {
+      "text": "A carriage (four-wheeled), coach"
+    }
+  ]
+}
+```
+
+And the 'short definition' is identical to the definition in 'definitions' array.
+
+```json
+{
+  "shortDefinition": "A carriage (four-wheeled), coach"
+}
+```
+
+So if you click on the 'show more' toggle, nothing changes (which is fine since there is only one definition)
+
+However, it should be obvious to the user that there is no point in clicking the toggle since they won't get any more
+info. What are your suggestions for acheiving this? The most obvious seems to me to be to hide the 'show more' link if
+there is only one definition.
+
+Here, there is only one definition but the detail is different from the short definition, so the 'show more' link should
+appear.
+
+```json
+{
+  "definitions": [
+    {
+      "text": "(hapax legomenon) a bogus spice"
+    }
+  ],
+  "shortDefinition": "a bogus spice"
+}
+
+```

--- a/src/detail/render-definitions.js
+++ b/src/detail/render-definitions.js
@@ -36,6 +36,10 @@ export function renderDefinitions(definitions, governedCase, partOfSpeech, subty
         return;
     }
 
+    if (isOnlyDefinitionSameAsShort(definitions, shortDefinition)) {
+        return;
+    }
+
     const hiddenList = buildDefinitionsList(definitions);
     hiddenList.classList.add(CSS_CLASSES.DEFINITIONS_HIDDEN);
     hiddenList.style.display = "none";
@@ -58,6 +62,15 @@ export function renderDefinitions(definitions, governedCase, partOfSpeech, subty
     });
 
     container.append(toggle);
+}
+
+// True if expanding would just repeat the shortDefinition already shown, so no toggle is needed
+export function isOnlyDefinitionSameAsShort(definitions, shortDefinition) {
+    return (
+        definitions.length === 1 &&
+        !(definitions[0].children && definitions[0].children.length > 0) &&
+        definitions[0].text === shortDefinition
+    );
 }
 
 // Recursively builds a numbered list from definition nodes ({ text, children? }).

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -229,7 +229,7 @@ label {
 #definitions-container {
     font-size: 1rem;
     text-align: left;
-    margin-left: 2rem;
+    margin-left: .5rem;
     margin-top: 1rem;
 }
 
@@ -242,28 +242,30 @@ label {
 .definitions-short {
     display: block;
     margin: 0.5rem 0;
+    padding-left: .5rem;
 }
 
 .definitions-list {
     margin: 0.5rem 0;
     list-style-type: decimal;
-    padding-left: 1.5rem;
+    padding-left: .5rem;
 }
 
 .definitions-list.definitions-unnumbered {
     list-style-type: none;
-    padding-left: 1rem;
+    padding-left: .5rem;
 }
 
 .definitions-toggle {
     border: none;
     padding: 0;
-    font-size: 0.95rem;
+    font-size: 0.90rem;
+    font-weight: 200;
     text-decoration: underline;
-    color: var(--color-text-header);
+    color: var(--color-brand-secondary-medium);
     background: none;
     cursor: pointer;
-    margin-left: 1.5rem;
+    margin-top: .5rem;
 }
 
 .definition-subheader {

--- a/test/detail/render-definitions.test.js
+++ b/test/detail/render-definitions.test.js
@@ -1,5 +1,5 @@
 import {describe, it, expect, beforeEach} from "vitest";
-import {renderDefinitions} from "@detail/render-definitions.js";
+import {renderDefinitions, isOnlyDefinitionSameAsShort} from "@detail/render-definitions.js";
 import {CSS_CLASSES, DEFINITIONS_TOGGLE_LABEL} from "@utilities/constants.js";
 
 function directChildren(list) {
@@ -140,5 +140,112 @@ describe("renderDefinitions", () => {
         const container = document.querySelector("#definitions-container");
         expect(container.querySelectorAll(`.${CSS_CLASSES.DEFINITIONS_SHORT}`)).toHaveLength(1);
         expect(container.querySelector(`.${CSS_CLASSES.DEFINITIONS_SHORT}`).textContent).toBe("short 2");
+    });
+
+    it("renders a nested tree with numbering only at levels with multiple nodes (magnus example)", () => {
+        const definitions = [
+            {
+                text: "(literally):",
+                children: [
+                    {text: "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)"},
+                    {
+                        text: "especially:",
+                        children: [
+                            {text: "great, much, abundant, considerable (of measure, weight, quantity)"},
+                            {text: "(rare, of time) synonym of longus, multus"},
+                            {text: "loud, powerful, strong, mighty (of voice)"},
+                        ],
+                    },
+                ],
+            },
+            {
+                text: "(figurative):",
+                children: [
+                    {text: "(in general) great, grand, mighty, noble, lofty, important, of great weight or importance, momentous"},
+                    {
+                        text: "(in particular):",
+                        children: [
+                            {text: "advanced in years, of great age, aged (of age, with nātu)"},
+                            {text: "(in specifications of value, in the neutral absolute) high, dear, of great value, at a high price"},
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        renderDefinitions(
+            definitions,
+            undefined,
+            "ADJECTIVE",
+            undefined,
+            "great, large, big; (of things) vast, extensive, spacious (of physical size or quantity)",
+        );
+
+        const container = document.querySelector("#definitions-container");
+        const topList = container.querySelector(`.${CSS_CLASSES.DEFINITIONS_LIST}`);
+
+        // Top level has two nodes, so it should be numbered
+        expect(topList.classList.contains(CSS_CLASSES.DEFINITIONS_UNNUMBERED)).toBe(false);
+        expect(directChildren(topList)).toHaveLength(2);
+
+        const literallyLi = directChildren(topList).find((li) => ownText(li) === "(literally):");
+        const literallyChildren = literallyLi.querySelector(`.${CSS_CLASSES.DEFINITIONS_LIST}`);
+        expect(directChildren(literallyChildren)).toHaveLength(2);
+
+        const especiallyLi = directChildren(literallyChildren).find((li) => ownText(li) === "especially:");
+        const especiallyChildren = especiallyLi.querySelector(`.${CSS_CLASSES.DEFINITIONS_LIST}`);
+        expect(especiallyChildren.classList.contains(CSS_CLASSES.DEFINITIONS_UNNUMBERED)).toBe(false);
+        expect(directChildren(especiallyChildren)).toHaveLength(3);
+    });
+
+    it("hides the toggle when the sole definition matches the shortDefinition (raeda example)", () => {
+        const definitions = [{text: "A carriage (four-wheeled), coach"}];
+
+        renderDefinitions(definitions, undefined, "NOUN", undefined, "A carriage (four-wheeled), coach");
+
+        const container = document.querySelector("#definitions-container");
+        expect(container.querySelector(`.${CSS_CLASSES.DEFINITIONS_TOGGLE}`)).toBeNull();
+        expect(container.querySelector(`.${CSS_CLASSES.DEFINITIONS_LIST}`)).toBeNull();
+        expect(container.querySelector(`.${CSS_CLASSES.DEFINITIONS_SHORT}`).textContent).toBe(
+            "A carriage (four-wheeled), coach",
+        );
+    });
+
+    it("shows the toggle when the sole definition differs from the shortDefinition (bogus spice example)", () => {
+        const definitions = [{text: "(hapax legomenon) a bogus spice"}];
+
+        renderDefinitions(definitions, undefined, "NOUN", undefined, "a bogus spice");
+
+        const container = document.querySelector("#definitions-container");
+        const toggle = container.querySelector(`.${CSS_CLASSES.DEFINITIONS_TOGGLE}`);
+        const hiddenList = container.querySelector(`.${CSS_CLASSES.DEFINITIONS_LIST}`);
+
+        expect(toggle).not.toBeNull();
+        expect(hiddenList.style.display).toBe("none");
+        expect(ownText(directChildren(hiddenList)[0])).toBe("(hapax legomenon) a bogus spice");
+    });
+});
+
+describe("isOnlyDefinitionSameAsShort", () => {
+    it("is true when there is one definition with no children and its text matches shortDefinition (raeda example)", () => {
+        const definitions = [{text: "A carriage (four-wheeled), coach"}];
+        expect(isOnlyDefinitionSameAsShort(definitions, "A carriage (four-wheeled), coach")).toBe(true);
+    });
+
+    it("is false when the sole definition's text differs from shortDefinition (bogus spice example)", () => {
+        const definitions = [{text: "(hapax legomenon) a bogus spice"}];
+        expect(isOnlyDefinitionSameAsShort(definitions, "a bogus spice")).toBe(false);
+    });
+
+    it("is false when there are multiple definitions", () => {
+        const definitions = [{text: "to love"}, {text: "to be fond of"}];
+        expect(isOnlyDefinitionSameAsShort(definitions, "to love")).toBe(false);
+    });
+
+    it("is false when the sole definition has children", () => {
+        const definitions = [
+            {text: "great, large, big", children: [{text: "especially:"}]},
+        ];
+        expect(isOnlyDefinitionSameAsShort(definitions, "great, large, big")).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- Fixes inconsistent CSS indentation in nested word definitions
- Hides the "show more" toggle when the sole definition is identical to the shortDefinition (e.g. `raeda`), since expanding it reveals nothing new
- Keeps the toggle when the sole definition differs from shortDefinition (e.g. bogus spice example)
- Extracts the check into `isOnlyDefinitionSameAsShort` for direct unit testing

## Test plan
- [x] `npm test` — 163 tests passing
- [x] New tests cover raeda (identical, no toggle), bogus spice (differs, toggle shown), and the nested magnus tree example from the planning doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)