### PR TITLE
docs: add release/branching workflow doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,14 @@ npx vitest run path/to/file.test.js  # single test file
 
 Tests default to jsdom environment (set in `vite.config.js`). Override per-file with `/* @vitest-environment jsdom */`.
 
+## Git workflow
+
+This project uses gitflow. See `docs/RELEASING.md` for the full release process.
+
+- `master` — production, deployed automatically on push. Only receives merges from `release/<version>` or `hotfix/<version>` branches.
+- `develop` — integration branch. All feature/fix branches PR into `develop`, never `master`.
+- Default PR base for feature/fix work is **`develop`**, not `master`.
+
 ## Architecture
 
 Vanilla JS, no framework. Vite build. ESM modules throughout.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing and Deployment
+
+This document contains the maintainer workflow for versioning, releasing, and deploying LexiconMeum frontend.
+
+## Deployment overview
+
+Production deployment is currently handled by GitHub Actions on pushes to `master`.
+
+Workflow file:
+
+- `.github/workflows/deploy.yml`
+
+## Branching model
+
+The current release flow is:
+
+- feature and integration work on `develop`
+- release preparation on `release/<version>`
+- production deploys from `master`
+
+## Versioning
+
+Project version is defined in `package.json`.
+
+## Release checklist
+
+### 1. Sync `develop`
+
+```bash 
+git checkout develop git pull origin develop
+```
+
+### 2. Create the release branch
+
+```bash
+git checkout -b release/<version> git push origin release/<version>
+```
+
+### 4. Open the release PR
+
+Open a pull request from:
+
+```bash 
+release/<version> -> master
+```
+
+Recommended PR content:
+
+- summary of changes
+- testing status
+- deployment notes
+- known issues, if any
+
+### 5. Merge and tag the release
+
+After the PR is merged:
+bash git checkout master git pull origin master git tag -a v<version> -m "Release <version>" git push origin v<version>
+
+### 6. Bump `develop` to the next version
+
+```bash 
+git checkout develop 
+git pull origin develop 
+```
+
+manually update package.json
+
+```bash
+git commit -am "Bump to <version>-SNAPSHOT"
+git push origin develop
+```
+


### PR DESCRIPTION
## Summary
- Adds `docs/RELEASING.md` documenting the gitflow branching model and release checklist
- References it from `CLAUDE.md` with an explicit rule: feature/fix branches PR into `develop`, master only receives `release/*`/`hotfix/*` merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)