### PR TITLE
Phone-friendly responsive UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist-ssr
 # Editor directories and files
 .idea/
 .DS_Store
+
+# Manual visual-check screenshots (not committed baselines)
+test/manual/screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ This project uses gitflow. See `docs/RELEASING.md` for the full release process.
 - `master` — production, deployed automatically on push. Only receives merges from `release/<version>` or `hotfix/<version>` branches.
 - `develop` — integration branch. All feature/fix branches PR into `develop`, never `master`.
 - Default PR base for feature/fix work is **`develop`**, not `master`.
+- Never run `git commit` unless the user explicitly asks for a commit in that turn. Implementing or approving a change
+  ("looks good", "keep it") is not a commit request — ask, or wait to be asked.
 
 ## Architecture
 

--- a/docs/planning/phone-friendly-ui.md
+++ b/docs/planning/phone-friendly-ui.md
@@ -1,0 +1,65 @@
+## Requirements
+
+## Don't break existing design
+
+The ipad and desktop versions look good, so make sure any changes don't break them.
+
+## Use Responsive Design Techniques
+
+Adhere to best practices for web ux and ui design
+
+## Usability Notes
+
+- When possible, preserve a view that allows the user to visually compare the different sets of forms.
+  Ex: Prefer allowing the outer grammar table to narrow so that three columns of forms are visible at once, rather than
+  breaking
+  it up into vertical stacks that the user has to scroll down to see. Do not, however do this at the expense of the
+  user's eyes. Font-size must be at least what is considered the best-practice minimum for phones.
+
+## Current State
+
+- No `viewport` meta tag exists in `index.html`. This is the root cause of most of the bad phone rendering: without
+  it, phones render the page at a virtual desktop width and zoom out, rather than laying out at the true device width.
+- No `@media` queries exist anywhere in `src/styles/`. All current responsiveness comes from `clamp()`/`vw` units
+  (banner) and `overflow-x: auto` fallback (inflection tables) — a blank slate for phone-specific rules.
+- The "three columns of forms" in the usability note refers to the adjective agreement table
+  (`render-adjective-agreement-table.js`), which renders up to 3 gender columns (m/f/n) per table via
+  `table-layout: fixed`. On a narrow phone this currently just horizontally scrolls rather than adapting.
+
+## Plan
+
+Each phase is independently shippable and testable — Playwright screenshots at phone (~390px), iPad (~768px), and
+desktop (~1280px) widths before/after each phase, checking the target fix landed and iPad/desktop stayed unchanged.
+
+### Phase 1 — Viewport foundation
+**What it does:** Fixes the root cause of phones rendering the site zoomed-out at desktop width. This alone should
+visibly improve almost everything, before any CSS is touched.
+- Add a standard responsive viewport meta tag to `index.html`.
+
+### Phase 2 — Header & search layout (`base.css`)
+**What it does:** Cleans up the search bar area (input, checkbox, banner) so it doesn't crowd or overflow on a
+narrow screen, and makes sure toast notifications aren't clipped at the screen edge.
+- Add a narrow-viewport breakpoint for `.grid-container` / `.header-container` / `.input-container` spacing so the
+  search input and "search word endings" checkbox don't crowd each other on small screens.
+- Let `.input-field`'s fixed 200px width become relative/fluid below the breakpoint so it scales with the viewport
+  instead of a hardcoded pixel value.
+- Adjust `.toast` positioning/width at narrow widths so it isn't clipped at the screen edge.
+
+### Phase 3 — Grammar tables (`inflection-table.css`)
+**What it does:** The core requirement — keeps the 2–3 column declension/agreement tables side-by-side and readable
+on a phone instead of forcing horizontal scroll, without shrinking text below the mobile-readable minimum.
+- Add a narrow-viewport breakpoint that trims the desktop-only cosmetic padding (e.g. the 4rem right padding on the
+  last column, the wider header padding) so the 2–3 column tables keep fitting side-by-side within the phone's
+  width, avoiding the horizontal-scroll fallback wherever reasonably possible.
+- Re-tune the fixed case-row/col-header widths at that breakpoint so they don't crowd out the form columns.
+- Verify table font-size stays at or above the mobile best-practice minimum as padding is trimmed.
+
+### Phase 4 — Conjugation tabs (`inflection-table.css`)
+**What it does:** Makes sure the Active/Passive/Participle tab bar stays usable and doesn't wrap awkwardly once the
+table it sits above has been narrowed in Phase 3.
+- Add a narrow-viewport adjustment to the conjugation tab bar (`.tab-item` padding/font-size).
+
+## Verification
+
+Each phase: launch the dev server, use Playwright (installed as a devDependency) to screenshot the page at phone/
+iPad/desktop viewport widths, and visually confirm the phase's fix landed and iPad/desktop are unchanged.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>LexiconMeum</title>
     <link rel="icon" type="image/x-icon" href="/images/favicon.ico"/>
     <link

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lexicon-meum-frontend",
-  "version": "0.9.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lexicon-meum-frontend",
-      "version": "0.9.0",
+      "version": "0.14.0",
       "dependencies": {
         "node": "^20.19.6"
       },
@@ -19,6 +19,7 @@
         "eslint-plugin-unicorn": "^61.0.2",
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
+        "playwright": "^1.61.1",
         "stylelint": "^16.26.1",
         "stylelint-order": "^7.0.0",
         "vite": "^7.0.4",
@@ -4685,6 +4686,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-unicorn": "^61.0.2",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
+    "playwright": "^1.61.1",
     "stylelint": "^16.26.1",
     "stylelint-order": "^7.0.0",
     "vite": "^7.0.4",

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,19 @@ wordSuggestionsBox.style.display = "none";
 // LOAD THEME FROM HTML
 document.documentElement.dataset.theme = "gold-gray";
 
+// SHOW/HIDE THE INFLECTION TABLE'S SCROLL-HINT FADE AS ITS CONTENT CHANGES OR SCROLLS
+const inflectionsContainer = document.querySelector("#inflections-container");
+
+function updateInflectionsScrollFade() {
+    const hasMoreToScroll = inflectionsContainer.scrollLeft + inflectionsContainer.clientWidth
+        < inflectionsContainer.scrollWidth - 1;
+    inflectionsContainer.classList.toggle(CSS_CLASSES.IS_SCROLLABLE, hasMoreToScroll);
+}
+
+new MutationObserver(updateInflectionsScrollFade).observe(inflectionsContainer, {childList: true, subtree: true});
+inflectionsContainer.addEventListener("scroll", updateInflectionsScrollFade);
+window.addEventListener("resize", updateInflectionsScrollFade);
+
 // Debouncing and race condition state
 let debounceTimer;
 let currentRequestId = 0;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -188,6 +188,32 @@ label {
 }
 
 /* =============================================================================
+   NARROW VIEWPORT (PHONE) ADJUSTMENTS
+   ============================================================================= */
+
+@media (max-width: 480px) {
+    .header-container {
+        gap: 1rem;
+    }
+
+    /* Let the checkbox drop to its own line instead of squeezing/wrapping its label text */
+    .input-with-checkbox {
+        flex-wrap: wrap;
+        row-gap: 0.5rem;
+    }
+
+    .input-field {
+        width: min(200px, 50vw);
+    }
+
+    /* Pin both edges so long messages wrap within the screen instead of overflowing past it */
+    .toast {
+        left: 20px;
+        right: 20px;
+    }
+}
+
+/* =============================================================================
    WORD DETAIL DISPLAY
    ============================================================================= */
 

--- a/src/styles/inflection-table.css
+++ b/src/styles/inflection-table.css
@@ -164,7 +164,29 @@ th[scope="col"].case-col-header {
 }
 
 #inflections-container {
+    position: relative; /* containing block for the scroll-hint fade below */
     overflow-x: auto;
+}
+
+/* Right-edge fade hinting there's more to scroll, shown only while content
+   actually overflows and hasn't been scrolled all the way to the end
+   (toggled in main.js). Fixed to the container's own edge rather than the
+   scrolled content, so it stays put as the user scrolls. */
+#inflections-container::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 24px;
+    background: linear-gradient(to right, transparent, var(--color-bg));
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+#inflections-container.is-scrollable::after {
+    opacity: 1;
 }
 
 #inflections-container H3 {

--- a/src/styles/inflection-table.css
+++ b/src/styles/inflection-table.css
@@ -257,4 +257,48 @@ th[scope="col"].case-col-header {
     border-top: none;
 }
 
+/* ==========================================================================
+   NARROW VIEWPORT (PHONE) ADJUSTMENTS
+
+   The desktop paddings above (in particular the 4rem right padding meant to
+   visually balance the last column) cost more width than a phone has to
+   spare, and were clipping the last form column instead of wrapping it into
+   view. Trim them so 2-3 form columns keep fitting side-by-side. Font-size
+   is left untouched so it stays at/above the mobile-readable minimum.
+   ========================================================================== */
+
+@media (max-width: 480px) {
+    .inflection-table {
+        padding: 0 0.25rem;
+    }
+
+    .inflection-table td:nth-child(2),
+    .inflection-table td:nth-child(3) {
+        padding-left: 0.4rem;
+    }
+
+    .inflection-table td:last-child {
+        padding-left: 0.4rem;
+        padding-right: 0.4rem;
+    }
+
+    .inflection-table thead th:nth-child(2),
+    .inflection-table thead th:nth-child(3) {
+        padding-left: 0.5rem;
+    }
+
+    .inflection-table thead th:last-child {
+        padding-left: 0.5rem;
+        padding-right: 0.4rem;
+    }
+
+    th[scope="row"].case-row-header,
+    th[scope="col"].case-col-header {
+        width: 2.4rem;
+        min-width: 2ch;
+        max-width: 4ch;
+        padding-left: 0.3rem;
+    }
+}
+
 

--- a/src/styles/inflection-table.css
+++ b/src/styles/inflection-table.css
@@ -321,6 +321,11 @@ th[scope="col"].case-col-header {
         max-width: 4ch;
         padding-left: 0.3rem;
     }
+
+    .tab-item {
+        padding: 0.5rem 0.3rem;
+        font-size: 0.85rem;
+    }
 }
 
 

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -80,6 +80,7 @@ export const CSS_CLASSES = Object.freeze({
 
     // Layout containers
     TABLE_GRID_CONTAINER: "table-grid-container",
+    IS_SCROLLABLE: "is-scrollable",
 
     // Tables
     INFLECTION_TABLE: "inflection-table",

--- a/test/manual/screenshot-viewports.js
+++ b/test/manual/screenshot-viewports.js
@@ -1,0 +1,31 @@
+// Reusable manual check: screenshots the app at phone/iPad/desktop widths.
+// Usage: node test/manual/screenshot-viewports.js [url]
+// Requires the dev server to already be running (npm run dev).
+
+import { chromium } from "playwright";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outputDir = path.join(__dirname, "screenshots");
+const url = process.argv[2] ?? "http://localhost:5173/";
+
+const viewports = {
+    phone: { width: 390, height: 844 },
+    ipad: { width: 768, height: 1024 },
+    desktop: { width: 1280, height: 800 },
+};
+
+const browser = await chromium.launch();
+
+for (const [name, viewport] of Object.entries(viewports)) {
+    const page = await browser.newPage({ viewport });
+    await page.goto(url);
+    await page.waitForLoadState("networkidle");
+    const outputPath = path.join(outputDir, `${name}.png`);
+    await page.screenshot({ path: outputPath, fullPage: true });
+    console.log(`Saved ${outputPath}`);
+    await page.close();
+}
+
+await browser.close();

--- a/test/manual/screenshot-word-detail.js
+++ b/test/manual/screenshot-word-detail.js
@@ -1,0 +1,67 @@
+// Reusable manual check: looks up a real word's data from the live backend,
+// then drives the app's actual search-and-render flow and screenshots the
+// resulting detail view at phone/iPad/desktop widths.
+//
+// Backend responses are fetched here in Node (not subject to browser CORS)
+// and replayed into the page via route interception, so this works even
+// when the local backend's CORS config blocks the dev server's origin.
+//
+// Usage: node test/manual/screenshot-word-detail.js <word> [partOfSpeech] [appUrl]
+// Example: node test/manual/screenshot-word-detail.js bonus ADJECTIVE
+
+import { chromium } from "playwright";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outputDir = path.join(__dirname, "screenshots");
+const word = process.argv[2];
+const partOfSpeech = process.argv[3];
+const appUrl = process.argv[4] ?? "http://localhost:5173/";
+const apiBaseUrl = process.env.VITE_API_BASE_URL ?? "http://localhost:8085/api/v1";
+
+if (!word) {
+    console.error("Usage: node test/manual/screenshot-word-detail.js <word> [partOfSpeech] [appUrl]");
+    process.exit(1);
+}
+
+const suggestionsRes = await fetch(`${apiBaseUrl}/lexemes/autocomplete/prefix?prefix=${encodeURIComponent(word)}`);
+const suggestions = await suggestionsRes.json();
+const match = suggestions.find(s => s.word === word && (!partOfSpeech || s.partOfSpeech === partOfSpeech));
+
+if (!match) {
+    console.error(`No suggestion found for "${word}"${partOfSpeech ? ` (${partOfSpeech})` : ""}`);
+    process.exit(1);
+}
+
+const detailRes = await fetch(`${apiBaseUrl}/lexemes/${match.lexemeId}/detail`);
+const detail = await detailRes.json();
+
+const viewports = {
+    phone: { width: 390, height: 844 },
+    ipad: { width: 768, height: 1024 },
+    desktop: { width: 1280, height: 800 },
+};
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+await page.route(url => url.pathname.includes("/autocomplete/prefix"), route =>
+    route.fulfill({ json: [match] }));
+await page.route(url => url.pathname.includes(`/lexemes/${match.lexemeId}/detail`), route =>
+    route.fulfill({ json: detail }));
+
+await page.goto(appUrl);
+await page.fill("#word-lookup-input", word);
+await page.waitForSelector("#word-suggestions div");
+await page.click("#word-suggestions div");
+await page.waitForSelector("#inflections-container table");
+
+for (const [name, viewport] of Object.entries(viewports)) {
+    await page.setViewportSize(viewport);
+    const outputPath = path.join(outputDir, `${word}-${name}.png`);
+    await page.screenshot({ path: outputPath, fullPage: true });
+    console.log(`Saved ${outputPath}`);
+}
+
+await browser.close();


### PR DESCRIPTION
## Summary
- Phase 1: add viewport meta tag (root cause of desktop-zoomed rendering on phones)
- Phase 2: responsive header/search layout and toast positioning on narrow widths
- Phase 3: trim desktop-only table padding so declension/agreement tables keep 2-3 columns side-by-side on phones, plus a scroll-hint fade for tables that still overflow
- Phase 4: shrink conjugation tab padding/font-size so the Active/Passive/Participle tab bar doesn't wrap on phones

See `docs/planning/phone-friendly-ui.md` for the full phased plan.

## Test plan
- [x] Playwright screenshots (`test/manual/screenshot-viewports.js`, `test/manual/screenshot-word-detail.js`) at phone/iPad/desktop widths for each phase
- [x] Verified noun (puella), adjective (bonus, macedonicus), and verb (amo) detail views render correctly on phone
- [x] Confirmed iPad/desktop views unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)