### PR TITLE
feat: add verbal noun section to participles tab

### DIFF
--- a/docs/planning/add-verbal-noun-section.md
+++ b/docs/planning/add-verbal-noun-section.md
@@ -1,0 +1,34 @@
+# Add Verbal Noun Section to Participles Tab
+
+Add a new function to render-participle-inflections.js called from renderParticipleInflections that will add a new
+section right below the list of Participle Tenses in the Participles Tab.
+The new section will contain Gerund and Supine inflection sets.
+
+The new section will only differ from the preceding participle tense rows in that instead of a single tense with the
+tense header and singular
+inflections in the left column and plural in the right, it will contain:
+
+- The tense name header and a set of Gerund inflections in the left tense column.
+- The tense name Header a set of Supine inflections in the right tense column.
+
+Below is an example of the json structure for Supine and Gerund. They will be the last two objects in each array of '
+participleTenses'. The Gerund structure will be the same. Only use the SINGULAR inflection set, since a single form is
+used for both
+singluar and plural in gerund and supine.
+
+```json
+ {
+  "altName": "Supine",
+  "declensions": {
+    "SINGULAR": {
+      "ACCUSATIVE": "amātum",
+      "ABLATIVE": "amātū"
+    },
+    "PLURAL": {
+      "ACCUSATIVE": "amātum",
+      "ABLATIVE": "amātū"
+    }
+  },
+  "defaultName": "Supine"
+}
+```

--- a/src/detail/verb/render-participle-inflections.js
+++ b/src/detail/verb/render-participle-inflections.js
@@ -20,7 +20,11 @@
  */
 
 import {renderDeclensionRow} from "@detail/render-declension-table.js";
+import {formatCaseNameForTableRowHeader, getSearchInput, highlightMatch, matchesInflection} from "@detail-core";
 import {CSS_CLASSES} from "@utilities";
+
+const GERUND = "gerund";
+const SUPINE = "supine";
 
 /**
  * Renders participle data using the CSS Grid system
@@ -58,7 +62,7 @@ export function renderParticipleInflections(participles, gender, tabSupport) {
 
     table.append(buildTableColumnHeaderRow());
     for (const participleTense of participleTenses) {
-        if (participleTense?.declensions) {
+        if (participleTense?.declensions && !isVerbalNoun(participleTense)) {
 
             const declensions = participleTense.declensions;
             const cases = Object.keys(declensions.SINGULAR);
@@ -86,7 +90,96 @@ export function renderParticipleInflections(participles, gender, tabSupport) {
             table.append(declensionSectionContainer);
         }
     }
+
+    const verbalNounSection = buildVerbalNounSection(participleTenses);
+    if (verbalNounSection) {
+        table.append(verbalNounSection);
+    }
+
     container.append(table);
+}
+
+function getTenseName(participleTense) {
+    return participleTense?.defaultName ?? participleTense?.altName ?? "";
+}
+
+function isVerbalNoun(participleTense) {
+    const name = getTenseName(participleTense).toLowerCase();
+    return name === GERUND || name === SUPINE;
+}
+
+/**
+ * Builds the verbal noun section: gerund forms in the left column, supine forms in the right.
+ * Only the SINGULAR set is used, since gerund and supine use one form for both numbers.
+ * @param {ParticipleTense[]} participleTenses - all tenses for the current gender
+ * @returns {HTMLTableSectionElement|undefined} the section, or undefined when neither verbal noun is present
+ */
+function buildVerbalNounSection(participleTenses) {
+    const gerund = participleTenses.find(tense => getTenseName(tense).toLowerCase() === GERUND);
+    const supine = participleTenses.find(tense => getTenseName(tense).toLowerCase() === SUPINE);
+
+    const gerundForms = gerund?.declensions?.SINGULAR;
+    const supineForms = supine?.declensions?.SINGULAR;
+    if (!gerundForms && !supineForms) {
+        return;
+    }
+
+    const section = document.createElement("tbody");
+    section.classList.add("participle-table", "declension-table");
+
+    // Empty case column header, matching the participle tense sections above
+    const emptyCaseHeader = document.createElement("th");
+    emptyCaseHeader.textContent = "Case";
+    emptyCaseHeader.scope = "col";
+    emptyCaseHeader.classList.add("case-col-header");
+    section.append(emptyCaseHeader);
+
+    section.append(buildVerbalNounHeader(gerund, "Gerund"));
+    section.append(buildVerbalNounHeader(supine, "Supine"));
+
+    for (const caseName of collectCaseNames(gerundForms, supineForms)) {
+        section.append(buildVerbalNounRow(caseName, gerundForms, supineForms));
+    }
+    return section;
+}
+
+// Single-column header for one verbal noun, or an empty placeholder when that form is missing
+function buildVerbalNounHeader(participleTense, fallbackName) {
+    const th = document.createElement("th");
+    th.classList.add("tense-header");
+    th.textContent = participleTense ? getTenseName(participleTense) || fallbackName : "";
+    return th;
+}
+
+// Cases present in either form, gerund order first
+function collectCaseNames(gerundForms, supineForms) {
+    return [...new Set([...Object.keys(gerundForms ?? {}), ...Object.keys(supineForms ?? {})])];
+}
+
+function buildVerbalNounRow(caseName, gerundForms, supineForms) {
+    const row = document.createElement("tr");
+
+    const caseCell = document.createElement("th");
+    caseCell.scope = "row";
+    caseCell.classList.add(CSS_CLASSES.CASE_ROW_HEADER);
+    caseCell.textContent = formatCaseNameForTableRowHeader(caseName);
+    row.append(caseCell);
+
+    row.append(buildVerbalNounCell(gerundForms?.[caseName]));
+    row.append(buildVerbalNounCell(supineForms?.[caseName]));
+    return row;
+}
+
+function buildVerbalNounCell(value) {
+    const cell = document.createElement("td");
+    const form = value || "";
+
+    if (matchesInflection(form, getSearchInput())) {
+        cell.append(highlightMatch(form));
+    } else {
+        cell.textContent = form;
+    }
+    return cell;
 }
 
 function buildTableColumnHeaderRow() {

--- a/test/detail/verb/render-participle-inflections.test.js
+++ b/test/detail/verb/render-participle-inflections.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderParticipleInflections } from '@detail/verb/render-participle-inflections.js';
+import { clearSearchInput, setSearchInputContext } from '@detail/detail-context.js';
+
+const participles = [{
+    voice: 'participle',
+    gender: 'MASCULINE',
+    tenses: [
+        {
+            defaultName: 'Present Participle',
+            declensions: {
+                SINGULAR: { NOMINATIVE: 'amāns', GENITIVE: 'amantis' },
+                PLURAL: { NOMINATIVE: 'amantēs', GENITIVE: 'amantium' }
+            }
+        },
+        {
+            defaultName: 'Gerund',
+            declensions: {
+                SINGULAR: { GENITIVE: 'amandī', DATIVE: 'amandō', ACCUSATIVE: 'amandum', ABLATIVE: 'amandō' },
+                PLURAL: { GENITIVE: 'amandī', DATIVE: 'amandō', ACCUSATIVE: 'amandum', ABLATIVE: 'amandō' }
+            }
+        },
+        {
+            defaultName: 'Supine',
+            declensions: {
+                SINGULAR: { ACCUSATIVE: 'amātum', ABLATIVE: 'amātū' },
+                PLURAL: { ACCUSATIVE: 'amātum', ABLATIVE: 'amātū' }
+            }
+        }
+    ]
+}];
+
+// The verbal noun section is the last tbody of the rendered table
+function getVerbalNounSection() {
+    const sections = document.querySelectorAll('#conjugation-table tbody');
+    return sections.item(sections.length - 1);
+}
+
+describe('renderParticipleInflections verbal noun section', () => {
+    beforeEach(() => {
+        clearSearchInput();
+        document.body.innerHTML = '<div id="inflections-container"></div>';
+    });
+
+    it('renders gerund and supine in their own section below the participle tenses', () => {
+        renderParticipleInflections(participles, 'MASCULINE');
+
+        const sections = document.querySelectorAll('#conjugation-table tbody');
+        expect(sections).toHaveLength(2);
+
+        const headers = [...getVerbalNounSection().querySelectorAll('th.tense-header')].map(th => th.textContent);
+        expect(headers).toEqual(['Gerund', 'Supine']);
+    });
+
+    it('does not render gerund or supine as regular participle tense sections', () => {
+        renderParticipleInflections(participles, 'MASCULINE');
+
+        const tenseHeaders = [...document.querySelectorAll('th.tense-header')]
+            .filter(th => th.colSpan === 2)
+            .map(th => th.textContent);
+        expect(tenseHeaders).toEqual(['Present Participle']);
+    });
+
+    it('aligns the union of cases, leaving a blank cell where a form is missing', () => {
+        renderParticipleInflections(participles, 'MASCULINE');
+
+        const rows = [...getVerbalNounSection().querySelectorAll('tr')]
+            .map(row => [...row.children].map(cell => cell.textContent));
+        expect(rows).toEqual([
+            ['Gen.', 'amandī', ''],
+            ['Dat.', 'amandō', ''],
+            ['Acc.', 'amandum', 'amātum'],
+            ['Abl.', 'amandō', 'amātū']
+        ]);
+    });
+
+    it('highlights a matching verbal noun form', () => {
+        setSearchInputContext('amatum');
+        renderParticipleInflections(participles, 'MASCULINE');
+
+        const marks = [...getVerbalNounSection().querySelectorAll('mark')].map(mark => mark.textContent);
+        expect(marks).toEqual(['amātum']);
+    });
+
+    it('omits the section when neither gerund nor supine is present', () => {
+        const withoutVerbalNouns = [{
+            ...participles[0],
+            tenses: [participles[0].tenses[0]]
+        }];
+
+        renderParticipleInflections(withoutVerbalNouns, 'MASCULINE');
+
+        expect(document.querySelectorAll('#conjugation-table tbody')).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a verbal noun section below the participle tenses in the Participles tab: gerund forms in the left column, supine in the right.

- Gerund and supine are identified by tense name and excluded from the normal participle tense sections.
- Rows are aligned on the union of the two case sets (gerund order first), leaving a blank cell where one of them has no form.
- Only the SINGULAR set is used, since both verbal nouns share a single form across numbers.
- Reuses the existing participle/declension table CSS; no style changes.

## Test plan

- New `test/detail/verb/render-participle-inflections.test.js` covers section placement, exclusion from tense sections, case alignment with blanks, search highlighting, and omission when neither form is present.
- `npm test` (180 passing) and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)