### PR TITLE
fix: align definitions list numbers with the Definitions label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,11 @@ npm run format:check # Prettier (check only)
 npm test             # run all tests (vitest)
 npm test -- --watch  # watch mode
 npx vitest run path/to/file.test.js  # single test file
+npx stylelint --config stylelintrc.cjs "src/**/*.css"  # CSS lint
 ```
+
+Before pushing, run every configured linter over the change — `npm run lint` (ESLint) and stylelint for CSS — plus
+`npm test`, and fix what they report.
 
 Tests default to jsdom environment (set in `vite.config.js`). Override per-file with `/* @vitest-environment jsdom */`.
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -274,7 +274,8 @@ label {
 .definitions-list {
     margin: 0.5rem 0;
     list-style-type: decimal;
-    padding-left: .5rem;
+    /* Reserve room for the outside marker so numbers align with the container's left edge */
+    padding-left: 1.5rem;
 }
 
 .definitions-list.definitions-unnumbered {
@@ -304,6 +305,7 @@ label {
 .definition-context {
     font-size: 0.90em;
     font-weight: 200;
+    color: var(--color-brand-secondary-medium);
 }
 
 .coming-soon {

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -67,7 +67,7 @@ export const KEY = Object.freeze({
 
 // ------- UI TEXT  ------ //
 export const DEFINITIONS_TOGGLE_LABEL = Object.freeze({
-    SHOW: "Show details",
+    SHOW: "Show more",
     HIDE: "Show less",
 });
 

--- a/test/detail/definitions-layout.test.js
+++ b/test/detail/definitions-layout.test.js
@@ -1,0 +1,92 @@
+// Layout regression test for the expanded definitions list.
+// jsdom does not lay out text or render list markers, so this renders the real
+// markup with the real stylesheet in headless Chromium and measures positions.
+
+import {describe, it, expect, beforeAll, afterAll} from "vitest";
+import {chromium} from "playwright";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {renderDefinitions} from "@detail/render-definitions.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const stylesDir = path.join(__dirname, "../../src/styles");
+
+const definitions = [
+    {text: "a first sense"},
+    {text: "a second sense"},
+    {text: "a third sense"},
+];
+
+let browser;
+
+beforeAll(async () => {
+    browser = await chromium.launch();
+});
+
+afterAll(async () => {
+    await browser?.close();
+});
+
+describe("expanded definitions list alignment", () => {
+    it("renders list numbers no further left than the Definitions label", async () => {
+        const markup = renderDefinitionsMarkup();
+        const css = await loadStyles();
+
+        const page = await browser.newPage();
+        await page.setContent(
+            `<style>${css}</style><div id="definitions-container">${markup}</div>`
+        );
+
+        const {labelLeft, markerLeft} = await page.evaluate(measureAlignment);
+        await page.close();
+
+        expect(markerLeft).toBeGreaterThanOrEqual(labelLeft - 1);
+    });
+});
+
+// Builds the real container markup by running the production renderer under jsdom
+function renderDefinitionsMarkup() {
+    document.body.innerHTML = `<div id="definitions-container"></div>`;
+    renderDefinitions(definitions, null, "NOUN", null, "a first sense");
+
+    const container = document.querySelector("#definitions-container");
+    // The toggle's click handler cannot cross into the browser page, so expand here
+    container.querySelector("ol").style.display = "block";
+
+    return container.innerHTML;
+}
+
+async function loadStyles() {
+    const [palette, base] = await Promise.all([
+        fs.readFile(path.join(stylesDir, "palette.css"), "utf8"),
+        fs.readFile(path.join(stylesDir, "base.css"), "utf8"),
+    ]);
+    return `${palette}\n${base}`;
+}
+
+// Runs in the browser: compares the label's left edge to where the list marker starts.
+// Markers are not in the DOM, so the marker's left edge is derived from the list item's
+// content edge minus the width of the marker text measured in the same font.
+function measureAlignment() {
+    const label = document.querySelector(".definitions-label");
+    const listItem = document.querySelector(".definitions-list > li");
+
+    const textRange = document.createRange();
+    textRange.selectNodeContents(listItem);
+    const listItemTextLeft = textRange.getBoundingClientRect().left;
+
+    const probe = document.createElement("span");
+    probe.style.font = getComputedStyle(listItem).font;
+    probe.style.position = "absolute";
+    probe.style.whiteSpace = "pre";
+    probe.textContent = "1.";
+    document.body.append(probe);
+    const markerWidth = probe.getBoundingClientRect().width;
+    probe.remove();
+
+    return {
+        labelLeft: label.getBoundingClientRect().left,
+        markerLeft: listItemTextLeft - markerWidth,
+    };
+}

--- a/test/detail/definitions-layout.test.js
+++ b/test/detail/definitions-layout.test.js
@@ -10,7 +10,7 @@ import {fileURLToPath} from "node:url";
 import {renderDefinitions} from "@detail/render-definitions.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const stylesDir = path.join(__dirname, "../../src/styles");
+const stylesDirectory = path.join(__dirname, "../../src/styles");
 
 const definitions = [
     {text: "a first sense"},
@@ -48,7 +48,7 @@ describe("expanded definitions list alignment", () => {
 // Builds the real container markup by running the production renderer under jsdom
 function renderDefinitionsMarkup() {
     document.body.innerHTML = `<div id="definitions-container"></div>`;
-    renderDefinitions(definitions, null, "NOUN", null, "a first sense");
+    renderDefinitions(definitions, undefined, "NOUN", undefined, "a first sense");
 
     const container = document.querySelector("#definitions-container");
     // The toggle's click handler cannot cross into the browser page, so expand here
@@ -59,8 +59,8 @@ function renderDefinitionsMarkup() {
 
 async function loadStyles() {
     const [palette, base] = await Promise.all([
-        fs.readFile(path.join(stylesDir, "palette.css"), "utf8"),
-        fs.readFile(path.join(stylesDir, "base.css"), "utf8"),
+        fs.readFile(path.join(stylesDirectory, "palette.css"), "utf8"),
+        fs.readFile(path.join(stylesDirectory, "base.css"), "utf8"),
     ]);
     return `${palette}\n${base}`;
 }


### PR DESCRIPTION
## Problem

`.definitions-list` overrode the UA default `padding-inline-start: 40px` with `.5rem`. That padding is narrower than the outside-positioned list marker, so when the definitions list was expanded the numbers were painted left of the container's content edge — i.e. the numbers were *less* indented than the "Definitions:" label, while the definition text was indented.

## Fix

`padding-left: 1.5rem` on `.definitions-list`, so the marker fits in the padding and lands at the container's left edge. `.definitions-unnumbered` is unchanged (no marker, so it was never affected).

## Test

Adds `test/detail/definitions-layout.test.js`. jsdom renders neither text metrics nor list markers, so this drives headless Chromium (playwright, already a devDependency):

1. Builds the real markup with the production `renderDefinitions` under jsdom, expanded.
2. Loads it with the real `palette.css` + `base.css` via `setContent`.
3. Derives the marker's left edge from the list item's text left minus the width of "1." measured in the same font, and asserts it isn't left of the label.

Verified it fails at `.5rem` and passes at `1.5rem`.

## Also included

- CLAUDE.md: note to run the configured linters before pushing, plus the stylelint command (configured via `stylelintrc.cjs`, but with no npm script).
- Two small in-flight tweaks to the definitions display: `.definition-context` color, and toggle label "Show details" -> "Show more".

Note: `npm run format:check` currently fails because `prettier` is not in `devDependencies`. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)