### PR TITLE
docs: fix formatting in RELEASING.md

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,21 +26,23 @@ Project version is defined in `package.json`.
 
 ### 1. Sync `develop`
 
-```bash 
-git checkout develop git pull origin develop
+```bash
+git checkout develop
+git pull origin develop
 ```
 
 ### 2. Create the release branch
 
 ```bash
-git checkout -b release/<version> git push origin release/<version>
+git checkout -b release/<version>
+git push origin release/<version>
 ```
 
-### 4. Open the release PR
+### 3. Open the release PR
 
 Open a pull request from:
 
-```bash 
+```
 release/<version> -> master
 ```
 
@@ -51,22 +53,27 @@ Recommended PR content:
 - deployment notes
 - known issues, if any
 
-### 5. Merge and tag the release
+### 4. Merge and tag the release
 
 After the PR is merged:
-bash git checkout master git pull origin master git tag -a v<version> -m "Release <version>" git push origin v<version>
 
-### 6. Bump `develop` to the next version
-
-```bash 
-git checkout develop 
-git pull origin develop 
+```bash
+git checkout master
+git pull origin master
+git tag -a v<version> -m "Release <version>"
+git push origin v<version>
 ```
 
-manually update package.json
+### 5. Bump `develop` to the next version
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+Manually update the version in `package.json`, then:
 
 ```bash
 git commit -am "Bump to <version>-SNAPSHOT"
 git push origin develop
 ```
-


### PR DESCRIPTION
Formatting only — no steps were added, removed, or changed in meaning.

- Split commands that had been run together on one line, e.g. `git checkout develop git pull origin develop` → two lines.
- Step 4 (merge and tag) had its commands as loose prose starting with a stray `bash`, with no code fence. Now fenced.
- The checklist numbering skipped 3 (it went 1, 2, 4, 5, 6). Renumbered 1–5. Checked the file's history: there was never a step 3 — the doc was committed that way, so nothing was lost.
- Dropped `bash` from the fence around `release/<version> -> master`, which isn't a shell command.

One thing left alone deliberately: there's no step covering the version bump *on the release branch* before it merges to `master`. The doc only bumps `develop` afterwards. That may be intentional or may be the gap where step 3 was meant to go — happy to add it if you want, but it's a content change rather than formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)